### PR TITLE
Enhance commands

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -2,9 +2,8 @@
 ; public_names = name of the executables
 
 (executables
- (names parse_main main)
- ; (names parse_main prettyprint_main)
- ; (public_names parse prettyprint)
+ (names parse_main prettyprint_main)
+ (public_names parse prettyprint)
  (libraries clang2cabs.lib)
- ; (package clang2cabs)
+ (package clang2cabs)
  )

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -1,5 +1,0 @@
-open Clang2cabs_lib
-
-let _ =
-  let fname = Array.get Sys.argv 1 in
-  Yojson2cabs.parse_yojson fname

--- a/src/bin/parse_main.ml
+++ b/src/bin/parse_main.ml
@@ -12,7 +12,10 @@ let run dir =
   Clang2yojson.convert_directory cmd dir
     |> List.iter (fun f ->
       print_endline ("converted: "^f);
-      Yojson2cabs.parse_yojson (f ^ ".yojson")
+      (* TODO: We should output serialized AST files instead of prettyprinting. *)
+      match Yojson2ast.parse_yojson (f ^ ".yojson") with
+      | Ok ast -> Printf.printf "%s" (Ast.show ast)
+      | Error (message, yojson) -> Printf.printf "%s\n%s\n" message yojson
     );
   Printf.printf "do parse c files in directory: '%s'\n" dir
 

--- a/src/bin/prettyprint_main.ml
+++ b/src/bin/prettyprint_main.ml
@@ -1,2 +1,32 @@
-;;
-print_endline "Hello! The version is %%VERSION%%"
+open Clang2cabs_lib
+open Util
+
+let run filename =
+  Printf.printf "%s" @@
+  match Yojson2ast.parse_yojson filename with
+  | Ok ast -> !%"%s" (Ast.show ast)
+  | Error (message, yojson) -> !%"%s\n%s\n" message yojson
+
+let help () =
+  let usage_msg =
+    !%"Usage: %s <filename>\n\
+       Parse yojson file and pretty print it\n"
+      Sys.argv.(0)
+  in
+  Printf.eprintf "%s%!" usage_msg
+
+let dispatch_command () =
+  assert (Array.length Sys.argv > 1);
+  match Sys.argv.(1) with
+  | "help" | "-h" | "-help" | "--help" -> help ()
+  | filename ->
+      run filename
+
+let main () =
+  let len = Array.length Sys.argv in
+  if len <= 1 then (
+    help ();
+    exit 1)
+  else dispatch_command ()
+
+let () = main ()

--- a/src/lib/yojson2ast.ml
+++ b/src/lib/yojson2ast.ml
@@ -518,8 +518,10 @@ let ast_of_yojson (fname:string) : Yojson.Safe.t -> Ast.file = function
           end
         in
         let typemap = make_typemap typedata in
+        (* For debbug *)
         show_typemap typemap;
         let function_typeinfo = make_fuction_typeinfo typemap typedata in
+        (* For debbug *)
         show_fuction_typeinfo function_typeinfo;
         let definitions = ast_of_yojson typemap function_typeinfo decls in
         fname, definitions
@@ -528,12 +530,6 @@ let ast_of_yojson (fname:string) : Yojson.Safe.t -> Ast.file = function
 
 let parse_yojson fname =
   let yojson = Yojson.Safe.from_file fname in
-  try (
-    yojson 
-    |> (ast_of_yojson fname) 
-    |> Ast.show
-    |> Printf.printf "%s\n"
-  ) with
+  try Ok (ast_of_yojson fname yojson) with
   | Invalid_Yojson (message, yojson) ->
-    Printf.printf "%s\n" message;
-    Format.printf "%a\n" Yojson.Safe.pp yojson
+    Error (message, Yojson.Safe.show yojson)

--- a/src/lib/yojson2ast.mli
+++ b/src/lib/yojson2ast.mli
@@ -1,0 +1,3 @@
+exception Invalid_Yojson of string * Yojson.Safe.t
+
+val parse_yojson : string -> (Ast.file, (string * string)) result

--- a/src/lib/yojson2cabs.mli
+++ b/src/lib/yojson2cabs.mli
@@ -1,1 +1,0 @@
-val parse_yojson : string -> unit


### PR DESCRIPTION
- correct filename (This code transforms yojson to ast, not to cabs)
- enhance interface ( `parse_yojson` outputs `Ast.file` instead of prettyprinting)