### PR TITLE
Add build-in types.

### DIFF
--- a/sample/types/types.c
+++ b/sample/types/types.c
@@ -1,0 +1,33 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+int test()
+{
+    bool b1;
+
+    char c1;
+    signed char c2;
+    unsigned char c3;
+
+    short s1;
+    signed short s2;
+    unsigned short s3;
+
+    int i1;
+    signed int i2;
+    unsigned int i3;
+
+    long l1;
+    signed long l2;
+    unsigned long l3;
+
+    long long ll1;
+    signed long long ll2;
+    unsigned long long ll3;
+
+    float f1;
+
+    double d1;
+
+    return 0;
+}

--- a/sample/types/types.c.yojson
+++ b/sample/types/types.c.yojson
@@ -1,0 +1,3885 @@
+<"TranslationUnitDecl" : (
+  {
+    "pointer" : 1,
+    "source_range" : (
+      {
+      },
+      {
+      }
+    )
+  },
+  [
+    <"TypedefDecl" : (
+      {
+        "pointer" : 2,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__int128_t",
+        "qual_name" : [
+          "__int128_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 3,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__uint128_t",
+        "qual_name" : [
+          "__uint128_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 4,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__NSConstantString",
+        "qual_name" : [
+          "__NSConstantString"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 5,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__builtin_ms_va_list",
+        "qual_name" : [
+          "__builtin_ms_va_list"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 6,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__builtin_va_list",
+        "qual_name" : [
+          "__builtin_va_list"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 7,
+        "source_range" : (
+          {
+            "file" : "/usr/include/x86_64-linux-gnu/bits/types.h",
+            "line" : 31,
+            "column" : 1
+          },
+          {
+            "column" : 23
+          }
+        )
+      },
+      {
+        "name" : "__u_char",
+        "qual_name" : [
+          "__u_char"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 8,
+        "source_range" : (
+          {
+            "line" : 32,
+            "column" : 1
+          },
+          {
+            "column" : 28
+          }
+        )
+      },
+      {
+        "name" : "__u_short",
+        "qual_name" : [
+          "__u_short"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 9,
+        "source_range" : (
+          {
+            "line" : 33,
+            "column" : 1
+          },
+          {
+            "column" : 22
+          }
+        )
+      },
+      {
+        "name" : "__u_int",
+        "qual_name" : [
+          "__u_int"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 10,
+        "source_range" : (
+          {
+            "line" : 34,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__u_long",
+        "qual_name" : [
+          "__u_long"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 11,
+        "source_range" : (
+          {
+            "line" : 37,
+            "column" : 1
+          },
+          {
+            "column" : 21
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int8_t",
+        "qual_name" : [
+          "__int8_t"
+        ]
+      },
+      12,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 13,
+        "source_range" : (
+          {
+            "line" : 38,
+            "column" : 1
+          },
+          {
+            "column" : 23
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint8_t",
+        "qual_name" : [
+          "__uint8_t"
+        ]
+      },
+      14,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 15,
+        "source_range" : (
+          {
+            "line" : 39,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int16_t",
+        "qual_name" : [
+          "__int16_t"
+        ]
+      },
+      16,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 17,
+        "source_range" : (
+          {
+            "line" : 40,
+            "column" : 1
+          },
+          {
+            "column" : 28
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint16_t",
+        "qual_name" : [
+          "__uint16_t"
+        ]
+      },
+      18,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 19,
+        "source_range" : (
+          {
+            "line" : 41,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int32_t",
+        "qual_name" : [
+          "__int32_t"
+        ]
+      },
+      20,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 21,
+        "source_range" : (
+          {
+            "line" : 42,
+            "column" : 1
+          },
+          {
+            "column" : 22
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint32_t",
+        "qual_name" : [
+          "__uint32_t"
+        ]
+      },
+      22,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 23,
+        "source_range" : (
+          {
+            "line" : 44,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int64_t",
+        "qual_name" : [
+          "__int64_t"
+        ]
+      },
+      24,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 25,
+        "source_range" : (
+          {
+            "line" : 45,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint64_t",
+        "qual_name" : [
+          "__uint64_t"
+        ]
+      },
+      26,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 27,
+        "source_range" : (
+          {
+            "line" : 52,
+            "column" : 1
+          },
+          {
+            "column" : 18
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int_least8_t",
+        "qual_name" : [
+          "__int_least8_t"
+        ]
+      },
+      28,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 29,
+        "source_range" : (
+          {
+            "line" : 53,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint_least8_t",
+        "qual_name" : [
+          "__uint_least8_t"
+        ]
+      },
+      30,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 31,
+        "source_range" : (
+          {
+            "line" : 54,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int_least16_t",
+        "qual_name" : [
+          "__int_least16_t"
+        ]
+      },
+      32,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 33,
+        "source_range" : (
+          {
+            "line" : 55,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint_least16_t",
+        "qual_name" : [
+          "__uint_least16_t"
+        ]
+      },
+      34,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 35,
+        "source_range" : (
+          {
+            "line" : 56,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int_least32_t",
+        "qual_name" : [
+          "__int_least32_t"
+        ]
+      },
+      36,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 37,
+        "source_range" : (
+          {
+            "line" : 57,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint_least32_t",
+        "qual_name" : [
+          "__uint_least32_t"
+        ]
+      },
+      38,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 39,
+        "source_range" : (
+          {
+            "line" : 58,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__int_least64_t",
+        "qual_name" : [
+          "__int_least64_t"
+        ]
+      },
+      40,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 41,
+        "source_range" : (
+          {
+            "line" : 59,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uint_least64_t",
+        "qual_name" : [
+          "__uint_least64_t"
+        ]
+      },
+      42,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 43,
+        "source_range" : (
+          {
+            "line" : 63,
+            "column" : 1
+          },
+          {
+            "column" : 18
+          }
+        )
+      },
+      {
+        "name" : "__quad_t",
+        "qual_name" : [
+          "__quad_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 44,
+        "source_range" : (
+          {
+            "line" : 64,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__u_quad_t",
+        "qual_name" : [
+          "__u_quad_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 45,
+        "source_range" : (
+          {
+            "line" : 72,
+            "column" : 1
+          },
+          {
+            "column" : 18
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__intmax_t",
+        "qual_name" : [
+          "__intmax_t"
+        ]
+      },
+      46,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 47,
+        "source_range" : (
+          {
+            "line" : 73,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__uintmax_t",
+        "qual_name" : [
+          "__uintmax_t"
+        ]
+      },
+      48,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 49,
+        "source_range" : (
+          {
+            "line" : 145,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__dev_t",
+        "qual_name" : [
+          "__dev_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 50,
+        "source_range" : (
+          {
+            "line" : 146,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__uid_t",
+        "qual_name" : [
+          "__uid_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 51,
+        "source_range" : (
+          {
+            "line" : 147,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__gid_t",
+        "qual_name" : [
+          "__gid_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 52,
+        "source_range" : (
+          {
+            "line" : 148,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__ino_t",
+        "qual_name" : [
+          "__ino_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 53,
+        "source_range" : (
+          {
+            "line" : 149,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__ino64_t",
+        "qual_name" : [
+          "__ino64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 54,
+        "source_range" : (
+          {
+            "line" : 150,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "__mode_t",
+        "qual_name" : [
+          "__mode_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 55,
+        "source_range" : (
+          {
+            "line" : 151,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__nlink_t",
+        "qual_name" : [
+          "__nlink_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 56,
+        "source_range" : (
+          {
+            "line" : 152,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__off_t",
+        "qual_name" : [
+          "__off_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 57,
+        "source_range" : (
+          {
+            "line" : 153,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        ),
+        "is_this_declaration_referenced" : true
+      },
+      {
+        "name" : "__off64_t",
+        "qual_name" : [
+          "__off64_t"
+        ]
+      },
+      58,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 59,
+        "source_range" : (
+          {
+            "line" : 154,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__pid_t",
+        "qual_name" : [
+          "__pid_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"RecordDecl" : (
+      {
+        "pointer" : 60,
+        "parent_pointer" : 1,
+        "source_range" : (
+          {
+            "line" : 155,
+            "column" : 12
+          },
+          {
+            "column" : 12
+          }
+        )
+      },
+      {
+        "name" : "",
+        "qual_name" : [
+          "__fsid_t"
+        ]
+      },
+      61,
+      [
+        <"FieldDecl" : (
+          {
+            "pointer" : 62,
+            "parent_pointer" : 60,
+            "source_range" : (
+              {
+                "column" : 12
+              },
+              {
+                "column" : 12
+              }
+            ),
+            "access" : <"Public">
+          },
+          {
+            "name" : "__val",
+            "qual_name" : [
+              "__val",
+              "__fsid_t"
+            ]
+          },
+          {
+            "type_ptr" : 63
+          },
+          {
+          }
+        )>
+      ],
+      {
+      },
+      <"TTK_Struct">,
+      {
+        "definition_ptr" : 60,
+        "is_complete_definition" : true
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 64,
+        "source_range" : (
+          {
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "__fsid_t",
+        "qual_name" : [
+          "__fsid_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 65,
+        "source_range" : (
+          {
+            "line" : 156,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__clock_t",
+        "qual_name" : [
+          "__clock_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 66,
+        "source_range" : (
+          {
+            "line" : 157,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "__rlim_t",
+        "qual_name" : [
+          "__rlim_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 67,
+        "source_range" : (
+          {
+            "line" : 158,
+            "column" : 1
+          },
+          {
+            "column" : 28
+          }
+        )
+      },
+      {
+        "name" : "__rlim64_t",
+        "qual_name" : [
+          "__rlim64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 68,
+        "source_range" : (
+          {
+            "line" : 159,
+            "column" : 1
+          },
+          {
+            "column" : 24
+          }
+        )
+      },
+      {
+        "name" : "__id_t",
+        "qual_name" : [
+          "__id_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 69,
+        "source_range" : (
+          {
+            "line" : 160,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "__time_t",
+        "qual_name" : [
+          "__time_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 70,
+        "source_range" : (
+          {
+            "line" : 161,
+            "column" : 1
+          },
+          {
+            "column" : 30
+          }
+        )
+      },
+      {
+        "name" : "__useconds_t",
+        "qual_name" : [
+          "__useconds_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 71,
+        "source_range" : (
+          {
+            "line" : 162,
+            "column" : 1
+          },
+          {
+            "column" : 31
+          }
+        )
+      },
+      {
+        "name" : "__suseconds_t",
+        "qual_name" : [
+          "__suseconds_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 72,
+        "source_range" : (
+          {
+            "line" : 164,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__daddr_t",
+        "qual_name" : [
+          "__daddr_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 73,
+        "source_range" : (
+          {
+            "line" : 165,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__key_t",
+        "qual_name" : [
+          "__key_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 74,
+        "source_range" : (
+          {
+            "line" : 168,
+            "column" : 1
+          },
+          {
+            "column" : 29
+          }
+        )
+      },
+      {
+        "name" : "__clockid_t",
+        "qual_name" : [
+          "__clockid_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 75,
+        "source_range" : (
+          {
+            "line" : 171,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__timer_t",
+        "qual_name" : [
+          "__timer_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 76,
+        "source_range" : (
+          {
+            "line" : 174,
+            "column" : 1
+          },
+          {
+            "column" : 29
+          }
+        )
+      },
+      {
+        "name" : "__blksize_t",
+        "qual_name" : [
+          "__blksize_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 77,
+        "source_range" : (
+          {
+            "line" : 179,
+            "column" : 1
+          },
+          {
+            "column" : 28
+          }
+        )
+      },
+      {
+        "name" : "__blkcnt_t",
+        "qual_name" : [
+          "__blkcnt_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 78,
+        "source_range" : (
+          {
+            "line" : 180,
+            "column" : 1
+          },
+          {
+            "column" : 30
+          }
+        )
+      },
+      {
+        "name" : "__blkcnt64_t",
+        "qual_name" : [
+          "__blkcnt64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 79,
+        "source_range" : (
+          {
+            "line" : 183,
+            "column" : 1
+          },
+          {
+            "column" : 30
+          }
+        )
+      },
+      {
+        "name" : "__fsblkcnt_t",
+        "qual_name" : [
+          "__fsblkcnt_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 80,
+        "source_range" : (
+          {
+            "line" : 184,
+            "column" : 1
+          },
+          {
+            "column" : 32
+          }
+        )
+      },
+      {
+        "name" : "__fsblkcnt64_t",
+        "qual_name" : [
+          "__fsblkcnt64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 81,
+        "source_range" : (
+          {
+            "line" : 187,
+            "column" : 1
+          },
+          {
+            "column" : 30
+          }
+        )
+      },
+      {
+        "name" : "__fsfilcnt_t",
+        "qual_name" : [
+          "__fsfilcnt_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 82,
+        "source_range" : (
+          {
+            "line" : 188,
+            "column" : 1
+          },
+          {
+            "column" : 32
+          }
+        )
+      },
+      {
+        "name" : "__fsfilcnt64_t",
+        "qual_name" : [
+          "__fsfilcnt64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 83,
+        "source_range" : (
+          {
+            "line" : 191,
+            "column" : 1
+          },
+          {
+            "column" : 28
+          }
+        )
+      },
+      {
+        "name" : "__fsword_t",
+        "qual_name" : [
+          "__fsword_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 84,
+        "source_range" : (
+          {
+            "line" : 193,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "__ssize_t",
+        "qual_name" : [
+          "__ssize_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 85,
+        "source_range" : (
+          {
+            "line" : 196,
+            "column" : 1
+          },
+          {
+            "column" : 33
+          }
+        )
+      },
+      {
+        "name" : "__syscall_slong_t",
+        "qual_name" : [
+          "__syscall_slong_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 86,
+        "source_range" : (
+          {
+            "line" : 198,
+            "column" : 1
+          },
+          {
+            "column" : 33
+          }
+        )
+      },
+      {
+        "name" : "__syscall_ulong_t",
+        "qual_name" : [
+          "__syscall_ulong_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 87,
+        "source_range" : (
+          {
+            "line" : 202,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "__loff_t",
+        "qual_name" : [
+          "__loff_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 88,
+        "source_range" : (
+          {
+            "line" : 203,
+            "column" : 1
+          },
+          {
+            "column" : 15
+          }
+        )
+      },
+      {
+        "name" : "__caddr_t",
+        "qual_name" : [
+          "__caddr_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 89,
+        "source_range" : (
+          {
+            "line" : 206,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "__intptr_t",
+        "qual_name" : [
+          "__intptr_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 90,
+        "source_range" : (
+          {
+            "line" : 209,
+            "column" : 1
+          },
+          {
+            "column" : 23
+          }
+        )
+      },
+      {
+        "name" : "__socklen_t",
+        "qual_name" : [
+          "__socklen_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 91,
+        "source_range" : (
+          {
+            "line" : 214,
+            "column" : 1
+          },
+          {
+            "column" : 13
+          }
+        )
+      },
+      {
+        "name" : "__sig_atomic_t",
+        "qual_name" : [
+          "__sig_atomic_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 92,
+        "source_range" : (
+          {
+            "file" : "/usr/include/x86_64-linux-gnu/bits/stdint-intn.h",
+            "line" : 24,
+            "column" : 1
+          },
+          {
+            "column" : 18
+          }
+        )
+      },
+      {
+        "name" : "int8_t",
+        "qual_name" : [
+          "int8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 93,
+        "source_range" : (
+          {
+            "line" : 25,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int16_t",
+        "qual_name" : [
+          "int16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 94,
+        "source_range" : (
+          {
+            "line" : 26,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int32_t",
+        "qual_name" : [
+          "int32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 95,
+        "source_range" : (
+          {
+            "line" : 27,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int64_t",
+        "qual_name" : [
+          "int64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 96,
+        "source_range" : (
+          {
+            "file" : "/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h",
+            "line" : 24,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "uint8_t",
+        "qual_name" : [
+          "uint8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 97,
+        "source_range" : (
+          {
+            "line" : 25,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        )
+      },
+      {
+        "name" : "uint16_t",
+        "qual_name" : [
+          "uint16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 98,
+        "source_range" : (
+          {
+            "line" : 26,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        )
+      },
+      {
+        "name" : "uint32_t",
+        "qual_name" : [
+          "uint32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 99,
+        "source_range" : (
+          {
+            "line" : 27,
+            "column" : 1
+          },
+          {
+            "column" : 20
+          }
+        )
+      },
+      {
+        "name" : "uint64_t",
+        "qual_name" : [
+          "uint64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 100,
+        "source_range" : (
+          {
+            "file" : "/usr/include/stdint.h",
+            "line" : 43,
+            "column" : 1
+          },
+          {
+            "column" : 24
+          }
+        )
+      },
+      {
+        "name" : "int_least8_t",
+        "qual_name" : [
+          "int_least8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 101,
+        "source_range" : (
+          {
+            "line" : 44,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "int_least16_t",
+        "qual_name" : [
+          "int_least16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 102,
+        "source_range" : (
+          {
+            "line" : 45,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "int_least32_t",
+        "qual_name" : [
+          "int_least32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 103,
+        "source_range" : (
+          {
+            "line" : 46,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "int_least64_t",
+        "qual_name" : [
+          "int_least64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 104,
+        "source_range" : (
+          {
+            "line" : 49,
+            "column" : 1
+          },
+          {
+            "column" : 25
+          }
+        )
+      },
+      {
+        "name" : "uint_least8_t",
+        "qual_name" : [
+          "uint_least8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 105,
+        "source_range" : (
+          {
+            "line" : 50,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "uint_least16_t",
+        "qual_name" : [
+          "uint_least16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 106,
+        "source_range" : (
+          {
+            "line" : 51,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "uint_least32_t",
+        "qual_name" : [
+          "uint_least32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 107,
+        "source_range" : (
+          {
+            "line" : 52,
+            "column" : 1
+          },
+          {
+            "column" : 26
+          }
+        )
+      },
+      {
+        "name" : "uint_least64_t",
+        "qual_name" : [
+          "uint_least64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 108,
+        "source_range" : (
+          {
+            "line" : 58,
+            "column" : 1
+          },
+          {
+            "column" : 22
+          }
+        )
+      },
+      {
+        "name" : "int_fast8_t",
+        "qual_name" : [
+          "int_fast8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 109,
+        "source_range" : (
+          {
+            "line" : 60,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int_fast16_t",
+        "qual_name" : [
+          "int_fast16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 110,
+        "source_range" : (
+          {
+            "line" : 61,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int_fast32_t",
+        "qual_name" : [
+          "int_fast32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 111,
+        "source_range" : (
+          {
+            "line" : 62,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "int_fast64_t",
+        "qual_name" : [
+          "int_fast64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 112,
+        "source_range" : (
+          {
+            "line" : 71,
+            "column" : 1
+          },
+          {
+            "column" : 24
+          }
+        )
+      },
+      {
+        "name" : "uint_fast8_t",
+        "qual_name" : [
+          "uint_fast8_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 113,
+        "source_range" : (
+          {
+            "line" : 73,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "uint_fast16_t",
+        "qual_name" : [
+          "uint_fast16_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 114,
+        "source_range" : (
+          {
+            "line" : 74,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "uint_fast32_t",
+        "qual_name" : [
+          "uint_fast32_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 115,
+        "source_range" : (
+          {
+            "line" : 75,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "uint_fast64_t",
+        "qual_name" : [
+          "uint_fast64_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 116,
+        "source_range" : (
+          {
+            "line" : 87,
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "intptr_t",
+        "qual_name" : [
+          "intptr_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 117,
+        "source_range" : (
+          {
+            "line" : 90,
+            "column" : 1
+          },
+          {
+            "column" : 27
+          }
+        )
+      },
+      {
+        "name" : "uintptr_t",
+        "qual_name" : [
+          "uintptr_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 118,
+        "source_range" : (
+          {
+            "line" : 101,
+            "column" : 1
+          },
+          {
+            "column" : 21
+          }
+        )
+      },
+      {
+        "name" : "intmax_t",
+        "qual_name" : [
+          "intmax_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 119,
+        "source_range" : (
+          {
+            "line" : 102,
+            "column" : 1
+          },
+          {
+            "column" : 22
+          }
+        )
+      },
+      {
+        "name" : "uintmax_t",
+        "qual_name" : [
+          "uintmax_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"FunctionDecl" : (
+      {
+        "pointer" : 120,
+        "source_range" : (
+          {
+            "file" : "../clang2cabs/sample/types/types.c",
+            "line" : 4,
+            "column" : 1
+          },
+          {
+            "line" : 33,
+            "column" : 1
+          }
+        )
+      },
+      {
+        "name" : "test",
+        "qual_name" : [
+          "test"
+        ]
+      },
+      {
+        "type_ptr" : 121
+      },
+      {
+        "decl_ptr_with_body" : 120,
+        "body" : <"CompoundStmt" : (
+          {
+            "pointer" : 122,
+            "source_range" : (
+              {
+                "line" : 5,
+                "column" : 1
+              },
+              {
+                "line" : 33,
+                "column" : 1
+              }
+            )
+          },
+          [
+            <"DeclStmt" : (
+              {
+                "pointer" : 123,
+                "source_range" : (
+                  {
+                    "line" : 6,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 12
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 124,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 10
+                      }
+                    )
+                  },
+                  {
+                    "name" : "b1",
+                    "qual_name" : [
+                      "b1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 125
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 126,
+                "source_range" : (
+                  {
+                    "line" : 8,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 12
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 127,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 10
+                      }
+                    )
+                  },
+                  {
+                    "name" : "c1",
+                    "qual_name" : [
+                      "c1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 128
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 129,
+                "source_range" : (
+                  {
+                    "line" : 9,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 19
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 130,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 17
+                      }
+                    )
+                  },
+                  {
+                    "name" : "c2",
+                    "qual_name" : [
+                      "c2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 131
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 132,
+                "source_range" : (
+                  {
+                    "line" : 10,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 21
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 133,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 19
+                      }
+                    )
+                  },
+                  {
+                    "name" : "c3",
+                    "qual_name" : [
+                      "c3"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 134
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 135,
+                "source_range" : (
+                  {
+                    "line" : 12,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 13
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 136,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 11
+                      }
+                    )
+                  },
+                  {
+                    "name" : "s1",
+                    "qual_name" : [
+                      "s1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 137
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 138,
+                "source_range" : (
+                  {
+                    "line" : 13,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 20
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 139,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 18
+                      }
+                    )
+                  },
+                  {
+                    "name" : "s2",
+                    "qual_name" : [
+                      "s2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 137
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 140,
+                "source_range" : (
+                  {
+                    "line" : 14,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 22
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 141,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 20
+                      }
+                    )
+                  },
+                  {
+                    "name" : "s3",
+                    "qual_name" : [
+                      "s3"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 142
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 143,
+                "source_range" : (
+                  {
+                    "line" : 16,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 11
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 144,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 9
+                      }
+                    )
+                  },
+                  {
+                    "name" : "i1",
+                    "qual_name" : [
+                      "i1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 145
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 146,
+                "source_range" : (
+                  {
+                    "line" : 17,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 18
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 147,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 16
+                      }
+                    )
+                  },
+                  {
+                    "name" : "i2",
+                    "qual_name" : [
+                      "i2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 145
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 148,
+                "source_range" : (
+                  {
+                    "line" : 18,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 20
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 149,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 18
+                      }
+                    )
+                  },
+                  {
+                    "name" : "i3",
+                    "qual_name" : [
+                      "i3"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 150
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 151,
+                "source_range" : (
+                  {
+                    "line" : 20,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 12
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 152,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 10
+                      }
+                    )
+                  },
+                  {
+                    "name" : "l1",
+                    "qual_name" : [
+                      "l1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 153
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 154,
+                "source_range" : (
+                  {
+                    "line" : 21,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 19
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 155,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 17
+                      }
+                    )
+                  },
+                  {
+                    "name" : "l2",
+                    "qual_name" : [
+                      "l2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 153
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 156,
+                "source_range" : (
+                  {
+                    "line" : 22,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 21
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 157,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 19
+                      }
+                    )
+                  },
+                  {
+                    "name" : "l3",
+                    "qual_name" : [
+                      "l3"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 158
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 159,
+                "source_range" : (
+                  {
+                    "line" : 24,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 18
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 160,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 15
+                      }
+                    )
+                  },
+                  {
+                    "name" : "ll1",
+                    "qual_name" : [
+                      "ll1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 161
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 162,
+                "source_range" : (
+                  {
+                    "line" : 25,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 25
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 163,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 22
+                      }
+                    )
+                  },
+                  {
+                    "name" : "ll2",
+                    "qual_name" : [
+                      "ll2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 161
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 164,
+                "source_range" : (
+                  {
+                    "line" : 26,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 27
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 165,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 24
+                      }
+                    )
+                  },
+                  {
+                    "name" : "ll3",
+                    "qual_name" : [
+                      "ll3"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 166
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 167,
+                "source_range" : (
+                  {
+                    "line" : 28,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 13
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 168,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 11
+                      }
+                    )
+                  },
+                  {
+                    "name" : "f1",
+                    "qual_name" : [
+                      "f1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 169
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 170,
+                "source_range" : (
+                  {
+                    "line" : 30,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 14
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 171,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 12
+                      }
+                    )
+                  },
+                  {
+                    "name" : "d1",
+                    "qual_name" : [
+                      "d1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 172
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"ReturnStmt" : (
+              {
+                "pointer" : 173,
+                "source_range" : (
+                  {
+                    "line" : 32,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 12
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 174,
+                    "source_range" : (
+                      {
+                        "column" : 12
+                      },
+                      {
+                        "column" : 12
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 145
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "0"
+                  }
+                )>
+              ]
+            )>
+          ]
+        )>
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 175,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "instancetype",
+        "qual_name" : [
+          "instancetype"
+        ]
+      },
+      176,
+      {
+      }
+    )>
+  ],
+  {
+  },
+  {
+    "input_path" : "../clang2cabs/sample/types/types.c",
+    "input_kind" : <"IK_C">,
+    "integer_type_widths" : {
+      "char_type" : 8,
+      "short_type" : 16,
+      "int_type" : 32,
+      "long_type" : 64,
+      "longlong_type" : 64
+    },
+    "types" : [
+      <"BuiltinType" : (
+        {
+          "pointer" : 177
+        },
+        <"Void">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 125
+        },
+        <"Bool">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 128
+        },
+        <"Char_S">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 131
+        },
+        <"SChar">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 137
+        },
+        <"Short">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 145
+        },
+        <"Int">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 153
+        },
+        <"Long">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 161
+        },
+        <"LongLong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 134
+        },
+        <"UChar">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 142
+        },
+        <"UShort">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 150
+        },
+        <"UInt">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 158
+        },
+        <"ULong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 166
+        },
+        <"ULongLong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 169
+        },
+        <"Float">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 172
+        },
+        <"Double">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 178
+        },
+        <"LongDouble">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 179
+        },
+        <"Float128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 180
+        },
+        <"Float16">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 181
+        },
+        <"ShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 182
+        },
+        <"Accum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 183
+        },
+        <"LongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 184
+        },
+        <"UShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 185
+        },
+        <"UAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 186
+        },
+        <"ULongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 187
+        },
+        <"ShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 188
+        },
+        <"Fract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 189
+        },
+        <"LongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 190
+        },
+        <"UShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 191
+        },
+        <"UFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 192
+        },
+        <"ULongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 193
+        },
+        <"SatShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 194
+        },
+        <"SatAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 195
+        },
+        <"SatLongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 196
+        },
+        <"SatUShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 197
+        },
+        <"SatUAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 198
+        },
+        <"SatULongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 199
+        },
+        <"SatShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 200
+        },
+        <"SatFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 201
+        },
+        <"SatLongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 202
+        },
+        <"SatUShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 203
+        },
+        <"SatUFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 204
+        },
+        <"SatULongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 205
+        },
+        <"Int128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 206
+        },
+        <"UInt128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 207
+        },
+        <"WChar_S">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 208
+        },
+        <"Char8">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 209
+        },
+        <"Dependent">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 210
+        },
+        <"Overload">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 211
+        },
+        <"BoundMember">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 212
+        },
+        <"PseudoObject">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 213
+        },
+        <"UnknownAny">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 214
+        },
+        <"ARCUnbridgedCast">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 215
+        },
+        <"BuiltinFn">
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 216
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 217
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 218
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 219
+        }
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 220
+        },
+        <"ObjCId">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 221
+        },
+        <"ObjCClass">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 222
+        },
+        <"ObjCSel">
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 223
+        },
+        {
+          "type_ptr" : 177
+        }
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 224
+        },
+        <"NullPtr">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 225
+        },
+        <"Half">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 226
+        },
+        <"BFloat16">
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 227
+        },
+        228
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 229
+        },
+        {
+          "type_ptr" : 145,
+          "is_const" : true
+        }
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 230
+        },
+        {
+          "type_ptr" : 128,
+          "is_const" : true
+        }
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 231
+        },
+        {
+          "type_ptr" : 128
+        }
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 232
+        },
+        233
+      )>,
+      <"ConstantArrayType" : (
+        {
+          "pointer" : 234
+        },
+        {
+          "element_type" : {
+            "type_ptr" : 232
+          },
+          "stride" : 24
+        },
+        1
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 12,
+          "desugared_type" : 131
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 131
+          },
+          "decl_ptr" : 11
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 14,
+          "desugared_type" : 134
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 134
+          },
+          "decl_ptr" : 13
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 16,
+          "desugared_type" : 137
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 137
+          },
+          "decl_ptr" : 15
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 18,
+          "desugared_type" : 142
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 142
+          },
+          "decl_ptr" : 17
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 20,
+          "desugared_type" : 145
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 145
+          },
+          "decl_ptr" : 19
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 22,
+          "desugared_type" : 150
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 150
+          },
+          "decl_ptr" : 21
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 24,
+          "desugared_type" : 153
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 153
+          },
+          "decl_ptr" : 23
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 26,
+          "desugared_type" : 158
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 158
+          },
+          "decl_ptr" : 25
+        }
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 61
+        },
+        60
+      )>,
+      <"ConstantArrayType" : (
+        {
+          "pointer" : 63
+        },
+        {
+          "element_type" : {
+            "type_ptr" : 145
+          },
+          "stride" : 4
+        },
+        2
+      )>,
+      <"ElaboratedType" : (
+        {
+          "pointer" : 235,
+          "desugared_type" : 61
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 58,
+          "desugared_type" : 153
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 153
+          },
+          "decl_ptr" : 57
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 28,
+          "desugared_type" : 131
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 12
+          },
+          "decl_ptr" : 27
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 32,
+          "desugared_type" : 137
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 16
+          },
+          "decl_ptr" : 31
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 36,
+          "desugared_type" : 145
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 20
+          },
+          "decl_ptr" : 35
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 40,
+          "desugared_type" : 153
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 24
+          },
+          "decl_ptr" : 39
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 30,
+          "desugared_type" : 134
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 14
+          },
+          "decl_ptr" : 29
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 34,
+          "desugared_type" : 142
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 18
+          },
+          "decl_ptr" : 33
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 38,
+          "desugared_type" : 150
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 22
+          },
+          "decl_ptr" : 37
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 42,
+          "desugared_type" : 158
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 26
+          },
+          "decl_ptr" : 41
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 46,
+          "desugared_type" : 153
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 153
+          },
+          "decl_ptr" : 45
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 48,
+          "desugared_type" : 158
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 158
+          },
+          "decl_ptr" : 47
+        }
+      )>,
+      <"FunctionNoProtoType" : (
+        {
+          "pointer" : 121
+        },
+        {
+          "return_type" : {
+            "type_ptr" : 145
+          }
+        }
+      )>,
+      <"ObjCObjectType" : (
+        {
+          "pointer" : 236
+        },
+        {
+          "base_type" : 220
+        }
+      )>,
+      <"ObjCObjectPointerType" : (
+        {
+          "pointer" : 237
+        },
+        {
+          "type_ptr" : 236
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 238,
+          "desugared_type" : 237
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 237
+          },
+          "decl_ptr" : 239
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 176,
+          "desugared_type" : 237
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 238
+          },
+          "decl_ptr" : 175
+        }
+      )>,
+      <"NoneType" : (
+        {
+          "pointer" : 0
+        }
+      )>
+    ]
+  }
+)>

--- a/src/bin/debug.ml
+++ b/src/bin/debug.ml
@@ -27,6 +27,9 @@ let dispatch_command () =
   | "help" | "-h" | "-help" | "--help" -> help ()
   | filename ->
      begin match run filename with
+     | Error (Yojson2ast.Invalid_Yojson (message, yojson)) ->
+      Printf.eprintf "%s%!" message;
+      Format.printf "%a\n" Yojson.Safe.pp yojson
      | Error exn -> raise exn
      | Ok () -> ()
      end

--- a/src/bin/debug.ml
+++ b/src/bin/debug.ml
@@ -28,7 +28,7 @@ let dispatch_command () =
   | filename ->
      begin match run filename with
      | Error (Yojson2ast.Invalid_Yojson (message, yojson)) ->
-      Printf.eprintf "%s%!" message;
+      Printf.printf "%s\n" message;
       Format.printf "%a\n" Yojson.Safe.pp yojson
      | Error exn -> raise exn
      | Ok () -> ()

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -26,8 +26,6 @@ and decl_type =
   | PTR of decl_type
   | ARRAY of decl_type * expression
 
-and field_group = specifier * (name * expression option) list
-
 and init_name_group = specifier * init_name list
 
 and name = string * decl_type
@@ -89,21 +87,6 @@ let rec show_file indent = function (filename, definition_list) ->
   ")"
 and show_name (name, decl_type) =
   name ^ (show_decl_type decl_type)
-(* and show_field_group (specifier, name_expr_list) =
-  let name_expr_list =
-    name_expr_list
-    |>List.map (function
-    | (name, Some expr) ->
-      "  " ^ show_name name ^ " = " ^ show_expression expr ^ "\n"
-    | (name, None) ->
-      "  " ^ show_name name ^ "\n"
-    )
-    |> String.concat "\n"
-  in
-  show_specifier specifier ^
-  "[\n" ^
-   name_expr_list ^
-  "]" *)
 and show_definition indent = function
   | FUNDEF ((return_type, func_name), single_name_list, block) ->
     let args =

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -4,7 +4,20 @@ type file = string * definition list
 
 and type_specifier =
   | Tvoid
+  | Tbool
+  | Tchar_s
+  | Tchar
+  | Tuchar
+  | Tshort
+  | Tushort
   | Tint
+  | Tuint
+  | Tlong
+  | Tulong
+  | Tlonglong
+  | Tulonglong
+  | Tfloat
+  | Tdouble
 
 and specifier = type_specifier list
 
@@ -12,6 +25,8 @@ and decl_type =
   | JUSTBASE
   | PTR of decl_type
   | ARRAY of decl_type * expression
+
+and field_group = specifier * (name * expression option) list
 
 and init_name_group = specifier * init_name list
 
@@ -74,6 +89,21 @@ let rec show_file indent = function (filename, definition_list) ->
   ")"
 and show_name (name, decl_type) =
   name ^ (show_decl_type decl_type)
+(* and show_field_group (specifier, name_expr_list) =
+  let name_expr_list =
+    name_expr_list
+    |>List.map (function
+    | (name, Some expr) ->
+      "  " ^ show_name name ^ " = " ^ show_expression expr ^ "\n"
+    | (name, None) ->
+      "  " ^ show_name name ^ "\n"
+    )
+    |> String.concat "\n"
+  in
+  show_specifier specifier ^
+  "[\n" ^
+   name_expr_list ^
+  "]" *)
 and show_definition indent = function
   | FUNDEF ((return_type, func_name), single_name_list, block) ->
     let args =
@@ -122,7 +152,20 @@ and show_specifier specifier_list =
   String.concat ", " @@ List.map show_type_specifier specifier_list
 and show_type_specifier = function
   | Tvoid -> "void"
-  | Tint -> "int"
+  | Tbool -> "bool"
+  | Tchar_s -> "char"
+  | Tchar -> "signed char"
+  | Tuchar -> "unsigned char"
+  | Tshort -> "signed short"
+  | Tushort -> "unsigned short"
+  | Tint -> "signed int"
+  | Tuint -> "unsigned int"
+  | Tlong -> "signed long"
+  | Tulong -> "unsigned long"
+  | Tlonglong -> "signed long long"
+  | Tulonglong -> "unsigned long long"
+  | Tfloat -> "float"
+  | Tdouble -> "double"
 and show_block indent block =
   block
   |> List.map (show_statement indent)

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -2,7 +2,20 @@ type file = string * definition list
 
 and type_specifier =
   | Tvoid (** [void] type *)
-  | Tint (** [int] type *)
+  | Tbool (** [bool] type *)
+  | Tchar_s (** [char] type *)
+  | Tchar (** [signed char] type *)
+  | Tuchar (** [unsigned char] type *)
+  | Tshort (** [signed short] type *)
+  | Tushort (** [unsigned short] type *)
+  | Tint (** [signed int] type *)
+  | Tuint (** [unsigned int] type *)
+  | Tlong (** [signed long] type *)
+  | Tulong (** [unsigned long] type *)
+  | Tlonglong (** [signed long long] type *)
+  | Tulonglong (** [unsigned long long] type *)
+  | Tfloat (** [float] type *)
+  | Tdouble (** [double] type *)
 
 (**
    In the 'small C' range, only type information is passed here.
@@ -25,6 +38,9 @@ and decl_type =
   e.g.
     {[int x = 1, y = 2;]}
  *)
+
+and field_group = specifier * (name * expression option) list
+
 and init_name_group = specifier * init_name list
 
 (**

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -39,8 +39,6 @@ and decl_type =
     {[int x = 1, y = 2;]}
  *)
 
-and field_group = specifier * (name * expression option) list
-
 and init_name_group = specifier * init_name list
 
 (**

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -1,4 +1,5 @@
 exception Cannot_convert of string
+exception Unimplemented_error of string
 
 let dummy_loc: Cabs.cabsloc = {
   lineno= 0;
@@ -101,9 +102,23 @@ and conv_block block : Cabs.block = {
   bstmts= List.map conv_statement block
 }
 
+(* and conv_field_group (specifier, name_expr_list) =
+  let specifier = conv_specifiler specifier in
+  let name_expr_list = 
+    name_expr_list
+    |> List.map (fun (name, expr_opt) ->
+      (
+        conv_name name,
+        Option.map conv_expression expr_opt
+      )
+    )
+  in
+  specifier, name_expr_list *)
+
 and conv_type_specifier : Ast.type_specifier -> Cabs.typeSpecifier = function
   | Ast.Tvoid -> Cabs.Tvoid
   | Ast.Tint -> Cabs.Tint
+  | _ -> raise (Unimplemented_error "Cabs cannot accept this type.")
 
 and conv_specifiler type_specifiers : Cabs.specifier =
   List.map (fun ts -> Cabs.SpecType (conv_type_specifier ts)) type_specifiers

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -102,19 +102,6 @@ and conv_block block : Cabs.block = {
   bstmts= List.map conv_statement block
 }
 
-(* and conv_field_group (specifier, name_expr_list) =
-  let specifier = conv_specifiler specifier in
-  let name_expr_list = 
-    name_expr_list
-    |> List.map (fun (name, expr_opt) ->
-      (
-        conv_name name,
-        Option.map conv_expression expr_opt
-      )
-    )
-  in
-  specifier, name_expr_list *)
-
 and conv_type_specifier : Ast.type_specifier -> Cabs.typeSpecifier = function
   | Ast.Tvoid -> Cabs.Tvoid
   | Ast.Tint -> Cabs.Tint

--- a/src/lib/cabs.ml
+++ b/src/lib/cabs.ml
@@ -23,6 +23,8 @@ and decl_type =
 
 and name_group = specifier * name list
 
+and field_group = specifier * (name * expression option) list
+
 and init_name_group = specifier * init_name list
 
 and name = string * decl_type * attribute list * cabsloc

--- a/src/lib/yojson2ast.ml
+++ b/src/lib/yojson2ast.ml
@@ -32,11 +32,37 @@ let make_typemap typedata = List.fold_left (fun map -> function
   | `Variant (
     "BuiltinType", Some (`Tuple (
       `Assoc [("pointer", `Int i)] ::
-      `Variant ("Int", None) ::
+      `Variant ((
+        "Bool" |
+        "Char_S" | "SChar" | "UChar" |
+        "Short" | "UShort" |
+        "Int" | "UInt" |
+        "Long" | "ULong" | 
+        "LongLong" | "ULongLong" |
+        "Float" |
+        "Double"
+      ) as tpe, None) ::
       _
     ))
-  ) ->
-    PointerMap.add i (Just Ast.Tint) map
+  ) as yojson ->
+    let tpe = match tpe with
+    | "Bool"  -> Ast.Tbool
+    | "Char_S" -> Ast.Tchar_s
+    | "SChar" -> Ast.Tchar
+    | "UChar" -> Ast.Tuchar
+    | "Short" -> Ast.Tshort
+    | "UShort" -> Ast.Tushort
+    | "Int" -> Ast.Tint
+    | "UInt" -> Ast.Tuint
+    | "Long" -> Ast.Tlong
+    | "ULong" -> Ast.Tulong
+    | "LongLong" -> Ast.Tlonglong
+    | "ULongLong" -> Ast.Tulonglong
+    | "Float" -> Ast.Tfloat
+    | "Double" -> Ast.Tdouble
+    | _ -> raise (Invalid_Yojson ("Invalid buildin type.", yojson))
+    in
+    PointerMap.add i (Just tpe) map
   | `Variant (
     "BuiltinType", Some (`Tuple (
       `Assoc [("pointer", `Int i)] ::
@@ -96,7 +122,7 @@ let parse_params_type typemap params_type yojson =
       | `Assoc[("type_ptr", `Int ptr)] ->
         begin match PointerMap.find_opt ptr typemap with
         | Some typ -> typ
-        | None -> raise (Invalid_Yojson ("Type not found", yojson))
+        | None -> raise (Invalid_Yojson ("Type not found. ptr: " ^ string_of_int ptr, yojson))
         end
       | _ -> raise (Invalid_Yojson ("type_ptr not found", yojson))
     )


### PR DESCRIPTION
The following types have been added.
`int` `short` `long` `long long` `float` `double` and `bool` (this type was added in C99)

Signed and unsigned are treated as separate types according to the type definition.