### PR TITLE
Add variables' metadata to Ast

### DIFF
--- a/sample/metadata/is_global.c
+++ b/sample/metadata/is_global.c
@@ -1,0 +1,8 @@
+int x, y = 1;
+static int z, w = 2;
+
+void test()
+{
+    int a, b = 42;
+    static int c, d = 99;
+}

--- a/sample/metadata/is_global.c.yojson
+++ b/sample/metadata/is_global.c.yojson
@@ -1,0 +1,1082 @@
+<"TranslationUnitDecl" : (
+  {
+    "pointer" : 1,
+    "source_range" : (
+      {
+      },
+      {
+      }
+    )
+  },
+  [
+    <"TypedefDecl" : (
+      {
+        "pointer" : 2,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__int128_t",
+        "qual_name" : [
+          "__int128_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 3,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__uint128_t",
+        "qual_name" : [
+          "__uint128_t"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 4,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__NSConstantString",
+        "qual_name" : [
+          "__NSConstantString"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 5,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__builtin_ms_va_list",
+        "qual_name" : [
+          "__builtin_ms_va_list"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 6,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "__builtin_va_list",
+        "qual_name" : [
+          "__builtin_va_list"
+        ]
+      },
+      0,
+      {
+      }
+    )>,
+    <"VarDecl" : (
+      {
+        "pointer" : 7,
+        "source_range" : (
+          {
+            "file" : "../clang2cabs/sample/metadata/is_global.c",
+            "line" : 1,
+            "column" : 1
+          },
+          {
+            "column" : 5
+          }
+        )
+      },
+      {
+        "name" : "x",
+        "qual_name" : [
+          "x"
+        ]
+      },
+      {
+        "type_ptr" : 8
+      },
+      {
+        "is_global" : true
+      }
+    )>,
+    <"VarDecl" : (
+      {
+        "pointer" : 9,
+        "source_range" : (
+          {
+            "column" : 1
+          },
+          {
+            "column" : 12
+          }
+        )
+      },
+      {
+        "name" : "y",
+        "qual_name" : [
+          "y"
+        ]
+      },
+      {
+        "type_ptr" : 8
+      },
+      {
+        "is_global" : true,
+        "is_init_ice" : true,
+        "init_expr" : <"IntegerLiteral" : (
+          {
+            "pointer" : 10,
+            "source_range" : (
+              {
+                "column" : 12
+              },
+              {
+                "column" : 12
+              }
+            )
+          },
+          [
+          ],
+          {
+            "qual_type" : {
+              "type_ptr" : 8
+            }
+          },
+          {
+            "is_signed" : true,
+            "bitwidth" : 32,
+            "value" : "1"
+          }
+        )>
+      }
+    )>,
+    <"VarDecl" : (
+      {
+        "pointer" : 11,
+        "source_range" : (
+          {
+            "line" : 2,
+            "column" : 1
+          },
+          {
+            "column" : 12
+          }
+        )
+      },
+      {
+        "name" : "z",
+        "qual_name" : [
+          "z"
+        ]
+      },
+      {
+        "type_ptr" : 8
+      },
+      {
+        "is_global" : true,
+        "is_static" : true
+      }
+    )>,
+    <"VarDecl" : (
+      {
+        "pointer" : 12,
+        "source_range" : (
+          {
+            "column" : 1
+          },
+          {
+            "column" : 19
+          }
+        )
+      },
+      {
+        "name" : "w",
+        "qual_name" : [
+          "w"
+        ]
+      },
+      {
+        "type_ptr" : 8
+      },
+      {
+        "is_global" : true,
+        "is_static" : true,
+        "is_init_ice" : true,
+        "init_expr" : <"IntegerLiteral" : (
+          {
+            "pointer" : 13,
+            "source_range" : (
+              {
+                "column" : 19
+              },
+              {
+                "column" : 19
+              }
+            )
+          },
+          [
+          ],
+          {
+            "qual_type" : {
+              "type_ptr" : 8
+            }
+          },
+          {
+            "is_signed" : true,
+            "bitwidth" : 32,
+            "value" : "2"
+          }
+        )>
+      }
+    )>,
+    <"FunctionDecl" : (
+      {
+        "pointer" : 14,
+        "source_range" : (
+          {
+            "line" : 4,
+            "column" : 1
+          },
+          {
+            "line" : 8,
+            "column" : 1
+          }
+        )
+      },
+      {
+        "name" : "test",
+        "qual_name" : [
+          "test"
+        ]
+      },
+      {
+        "type_ptr" : 15
+      },
+      {
+        "decl_ptr_with_body" : 14,
+        "body" : <"CompoundStmt" : (
+          {
+            "pointer" : 16,
+            "source_range" : (
+              {
+                "line" : 5,
+                "column" : 1
+              },
+              {
+                "line" : 8,
+                "column" : 1
+              }
+            )
+          },
+          [
+            <"DeclStmt" : (
+              {
+                "pointer" : 17,
+                "source_range" : (
+                  {
+                    "line" : 6,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 18
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 18,
+                    "source_range" : (
+                      {
+                        "column" : 16
+                      },
+                      {
+                        "column" : 16
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 8
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "42"
+                  }
+                )>
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 19,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 9
+                      }
+                    )
+                  },
+                  {
+                    "name" : "a",
+                    "qual_name" : [
+                      "a"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 8
+                  },
+                  {
+                  }
+                )>,
+                <"VarDecl" : (
+                  {
+                    "pointer" : 20,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 16
+                      }
+                    )
+                  },
+                  {
+                    "name" : "b",
+                    "qual_name" : [
+                      "b"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 8
+                  },
+                  {
+                    "is_init_ice" : true,
+                    "init_expr" : <"IntegerLiteral" : (
+                      {
+                        "pointer" : 18,
+                        "source_range" : (
+                          {
+                            "column" : 16
+                          },
+                          {
+                            "column" : 16
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 8
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "42"
+                      }
+                    )>
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 21,
+                "source_range" : (
+                  {
+                    "line" : 7,
+                    "column" : 5
+                  },
+                  {
+                    "column" : 25
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 22,
+                    "source_range" : (
+                      {
+                        "column" : 23
+                      },
+                      {
+                        "column" : 23
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 8
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "99"
+                  }
+                )>
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 23,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 16
+                      }
+                    )
+                  },
+                  {
+                    "name" : "c",
+                    "qual_name" : [
+                      "c"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 8
+                  },
+                  {
+                    "is_global" : true,
+                    "is_static" : true,
+                    "is_static_local" : true
+                  }
+                )>,
+                <"VarDecl" : (
+                  {
+                    "pointer" : 24,
+                    "source_range" : (
+                      {
+                        "column" : 5
+                      },
+                      {
+                        "column" : 23
+                      }
+                    )
+                  },
+                  {
+                    "name" : "d",
+                    "qual_name" : [
+                      "d"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 8
+                  },
+                  {
+                    "is_global" : true,
+                    "is_static" : true,
+                    "is_static_local" : true,
+                    "is_init_ice" : true,
+                    "init_expr" : <"IntegerLiteral" : (
+                      {
+                        "pointer" : 22,
+                        "source_range" : (
+                          {
+                            "column" : 23
+                          },
+                          {
+                            "column" : 23
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 8
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "99"
+                      }
+                    )>
+                  }
+                )>
+              ]
+            )>
+          ]
+        )>
+      }
+    )>,
+    <"TypedefDecl" : (
+      {
+        "pointer" : 25,
+        "source_range" : (
+          {
+          },
+          {
+          }
+        ),
+        "is_implicit" : true
+      },
+      {
+        "name" : "instancetype",
+        "qual_name" : [
+          "instancetype"
+        ]
+      },
+      26,
+      {
+      }
+    )>
+  ],
+  {
+  },
+  {
+    "input_path" : "../clang2cabs/sample/metadata/is_global.c",
+    "input_kind" : <"IK_C">,
+    "integer_type_widths" : {
+      "char_type" : 8,
+      "short_type" : 16,
+      "int_type" : 32,
+      "long_type" : 64,
+      "longlong_type" : 64
+    },
+    "types" : [
+      <"BuiltinType" : (
+        {
+          "pointer" : 27
+        },
+        <"Void">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 28
+        },
+        <"Bool">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 29
+        },
+        <"Char_S">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 30
+        },
+        <"SChar">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 31
+        },
+        <"Short">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 8
+        },
+        <"Int">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 32
+        },
+        <"Long">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 33
+        },
+        <"LongLong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 34
+        },
+        <"UChar">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 35
+        },
+        <"UShort">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 36
+        },
+        <"UInt">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 37
+        },
+        <"ULong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 38
+        },
+        <"ULongLong">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 39
+        },
+        <"Float">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 40
+        },
+        <"Double">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 41
+        },
+        <"LongDouble">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 42
+        },
+        <"Float128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 43
+        },
+        <"Float16">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 44
+        },
+        <"ShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 45
+        },
+        <"Accum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 46
+        },
+        <"LongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 47
+        },
+        <"UShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 48
+        },
+        <"UAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 49
+        },
+        <"ULongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 50
+        },
+        <"ShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 51
+        },
+        <"Fract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 52
+        },
+        <"LongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 53
+        },
+        <"UShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 54
+        },
+        <"UFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 55
+        },
+        <"ULongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 56
+        },
+        <"SatShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 57
+        },
+        <"SatAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 58
+        },
+        <"SatLongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 59
+        },
+        <"SatUShortAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 60
+        },
+        <"SatUAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 61
+        },
+        <"SatULongAccum">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 62
+        },
+        <"SatShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 63
+        },
+        <"SatFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 64
+        },
+        <"SatLongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 65
+        },
+        <"SatUShortFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 66
+        },
+        <"SatUFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 67
+        },
+        <"SatULongFract">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 68
+        },
+        <"Int128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 69
+        },
+        <"UInt128">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 70
+        },
+        <"WChar_S">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 71
+        },
+        <"Char8">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 72
+        },
+        <"Dependent">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 73
+        },
+        <"Overload">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 74
+        },
+        <"BoundMember">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 75
+        },
+        <"PseudoObject">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 76
+        },
+        <"UnknownAny">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 77
+        },
+        <"ARCUnbridgedCast">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 78
+        },
+        <"BuiltinFn">
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 79
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 80
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 81
+        }
+      )>,
+      <"ComplexType" : (
+        {
+          "pointer" : 82
+        }
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 83
+        },
+        <"ObjCId">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 84
+        },
+        <"ObjCClass">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 85
+        },
+        <"ObjCSel">
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 86
+        },
+        {
+          "type_ptr" : 27
+        }
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 87
+        },
+        <"NullPtr">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 88
+        },
+        <"Half">
+      )>,
+      <"BuiltinType" : (
+        {
+          "pointer" : 89
+        },
+        <"BFloat16">
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 90
+        },
+        91
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 92
+        },
+        {
+          "type_ptr" : 8,
+          "is_const" : true
+        }
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 93
+        },
+        {
+          "type_ptr" : 29,
+          "is_const" : true
+        }
+      )>,
+      <"PointerType" : (
+        {
+          "pointer" : 94
+        },
+        {
+          "type_ptr" : 29
+        }
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 95
+        },
+        96
+      )>,
+      <"ConstantArrayType" : (
+        {
+          "pointer" : 97
+        },
+        {
+          "element_type" : {
+            "type_ptr" : 95
+          },
+          "stride" : 24
+        },
+        1
+      )>,
+      <"FunctionNoProtoType" : (
+        {
+          "pointer" : 15
+        },
+        {
+          "return_type" : {
+            "type_ptr" : 27
+          }
+        }
+      )>,
+      <"ObjCObjectType" : (
+        {
+          "pointer" : 98
+        },
+        {
+          "base_type" : 83
+        }
+      )>,
+      <"ObjCObjectPointerType" : (
+        {
+          "pointer" : 99
+        },
+        {
+          "type_ptr" : 98
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 100,
+          "desugared_type" : 99
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 99
+          },
+          "decl_ptr" : 101
+        }
+      )>,
+      <"TypedefType" : (
+        {
+          "pointer" : 26,
+          "desugared_type" : 99
+        },
+        {
+          "child_type" : {
+            "type_ptr" : 100
+          },
+          "decl_ptr" : 25
+        }
+      )>,
+      <"NoneType" : (
+        {
+          "pointer" : 0
+        }
+      )>
+    ]
+  }
+)>

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -63,6 +63,15 @@ and init_name = name * init_expression
 and single_name = specifier * name
 
 (**
+  The variable's scope info.
+*)
+and variable_scope = {
+  is_global : bool;
+  is_static : bool;
+  is_static_local : bool
+}
+
+(**
    Declaration definition (at toplevel)
  *)
 and definition =
@@ -73,7 +82,7 @@ and definition =
      [args] is the arguments' names and types.
      [body] is the function's body and function prototype has empty body.
    *)
-  | DECDEF of init_name_group (** global variable(s) *)
+  | DECDEF of init_name_group * variable_scope (** global variable(s) *)
 
 and block = statement list
 
@@ -110,7 +119,7 @@ and statement =
   (** return statement
       {[return e;]}
    *)
-  | VARDECL of init_name_group
+  | VARDECL of init_name_group * variable_scope
   (** variable declaration *)
 
 and binary_operator =

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -93,7 +93,7 @@ let rec conv_statement : Ast.statement -> Cabs.statement = function
     Cabs.RETURN (conv_expression expression, dummy_loc)
   | Ast.RETURN None ->
     raise (Cannot_convert "Cabs does not support empty RETURN statement")
-  | Ast.VARDECL init_name_group ->
+  | Ast.VARDECL (init_name_group, _) ->
     Cabs.DEFINITION (Cabs.DECDEF (conv_init_name_group init_name_group, dummy_loc))
 
 and conv_block block : Cabs.block = {
@@ -143,7 +143,7 @@ let conv_definition : Ast.definition -> Cabs.definition = function
       dummy_loc,
       dummy_loc
     )
-  | Ast.DECDEF init_name_group ->
+  | Ast.DECDEF (init_name_group, _) ->
     Cabs.DECDEF (conv_init_name_group init_name_group, dummy_loc)
 
 let conv_file (filename, definitions) : Cabs.file = filename, List.map conv_definition definitions


### PR DESCRIPTION
The syntax tree of a variable definition now includes information on the scope of the variable.
- `is_global`
- `is_statc`
- `is_local_static`