### PR TITLE
Define Array and Pointer as Ast.ctype

### DIFF
--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -30,17 +30,8 @@ and ctype =
   | Tulonglong (** [unsigned long long] type *)
   | Tfloat (** [float] type *)
   | Tdouble (** [double] type *)
-
-(**
-  Declarator type. They modify the base type given in the specifier.
-  e.g.
-  - [int[3][4]] -> [ARRAY(ARRAY(JUSTBASE, "3"), "4")]
-  - [int]     -> [JUSTBASE]
-*)
-and decl_type =
-  | JUSTBASE
-  | PTR of decl_type (** This is not used currently. *)
-  | ARRAY of decl_type * expression
+  | Tarray of ctype * int (** [Array] type *)
+  | Tpointer of ctype (** [Pointer] type *)
 
 (**
   like name_group, except the declared variables are allowed to have initializers
@@ -51,14 +42,9 @@ and decl_type =
 and init_name_group = ctype * init_name list
 
 (**
-  The decl_type is in the order in which they are printed. Only the name of
-  the declared identifier is pulled out. The attributes are those that are
-  printed after the declarator
-  e.g.
-    in [int x[]], [x[]] is the declarator; [x] will be pulled out as
-    the string, and decl_type will be [ARRAY(JUSTBASE)]
+  A name of symbol.
  *)
-and name = string * decl_type
+and name = string
 
 (**
    A variable declarator [name] with an initializer [init_expression].

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -119,15 +119,9 @@ and conv_ctype : Ast.ctype -> Cabs.specifier = function
   | Ast.Tint -> [Cabs.SpecType Cabs.Tint]
   | _ -> raise (Unimplemented_error "Cabs cannot accept this type.")
 
-and conv_decl_type : Ast.decl_type -> Cabs.decl_type = function
-  | Ast.JUSTBASE -> Cabs.JUSTBASE
-  | Ast.PTR decl_type ->
-    Cabs.PTR ([], conv_decl_type decl_type)
-  | Ast.ARRAY (decl_type, expr) ->
-    Cabs.ARRAY (conv_decl_type decl_type, [], conv_expression expr)
-
-and conv_name (name, decl_type) : Cabs.name =
-  name, conv_decl_type decl_type, [], dummy_loc
+and conv_name name : Cabs.name =
+  (* CAUTION: We don't treat decl_types. *)
+  name, Cabs.JUSTBASE, [], dummy_loc
 
 and conv_single_name (ctype, name, _location) : Cabs.single_name =
   (conv_ctype ctype), (conv_name name)

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -22,6 +22,17 @@ let load_from_file filename =
   using_in filename (fun ch ->
       Marshal.from_channel ch)
 
+
+module Option = struct
+  include Option
+
+  let flat_map f m = bind m f
+
+  module Let = struct
+    let ( let* ) m f = bind m f
+  end
+end
+
 module List = struct
   include List
   

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -4,6 +4,16 @@ val save_to_file : string -> 'a -> (unit, exn) result
 
 val load_from_file : string -> ('a, exn) result
 
+module Option : sig
+  include module type of Option
+
+  val flat_map : ('a -> 'b option) -> 'a option -> 'b option
+
+  module Let : sig
+    val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option
+  end
+end
+
 module List : sig
   include module type of List
 


### PR DESCRIPTION
Array and Pointer used to be treated specially, but are now treated as a `ctype`.