### PR TITLE
Update user-defined type and Support struct type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The definition of "small C", the language to be parsed, is as follows:
 #include
 #define
 
+<struct-specifier> ::= struct { [type <identifier>]+ }
+
 P ::= x=e; | if (b) P else P | while (b) P | for (e; e; e) P | return e; | return;
         | { P ... P } | e++; | ++e; | e--; | --e;
 e ::= int-constants (..., -1, 0, 1, 2, ...) | variables | a[e]

--- a/sample/types/record.c
+++ b/sample/types/record.c
@@ -7,6 +7,14 @@ typedef struct {
   int a, b;
 } S2;
 
+struct S3;
+
+struct X {
+  unsigned int n : 16;
+  unsigned int m : (99 - 42) ? 16 : 32;
+  unsigned int a : 8, b : 8, : 8, c : 8;
+};
+
 int main(void)
 {
   struct S1 s11;
@@ -18,4 +26,10 @@ int main(void)
   s21.a = 42;
   s21.b = 99;
   S2 s22 = { 1, 2 };
+
+  struct X x1;
+  x1.n = 0;
+  x1.m = 1;
+
+  struct X x2 = { 0, 0, 0, 0, 0 };
 }

--- a/sample/types/record.c
+++ b/sample/types/record.c
@@ -32,4 +32,18 @@ int main(void)
   x1.m = 1;
 
   struct X x2 = { 0, 0, 0, 0, 0 };
+
+  struct A {
+    int n, m;
+  };
+  struct A a;
+  a.n = 42;
+  a.m = 99;
+
+  struct {
+    int id;
+    unsigned int age;
+  } user;
+  user.id = 0;
+  user.age = 20;
 }

--- a/sample/types/record.c.yojson
+++ b/sample/types/record.c.yojson
@@ -964,7 +964,7 @@
             "column" : 1
           },
           {
-            "line" : 35,
+            "line" : 49,
             "column" : 1
           }
         )
@@ -989,7 +989,7 @@
                 "column" : 1
               },
               {
-                "line" : 35,
+                "line" : 49,
                 "column" : 1
               }
             )
@@ -2916,6 +2916,855 @@
                   }
                 )>
               ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 107,
+                "source_range" : (
+                  {
+                    "line" : 36,
+                    "column" : 3
+                  },
+                  {
+                    "line" : 38,
+                    "column" : 4
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"RecordDecl" : (
+                  {
+                    "pointer" : 108,
+                    "parent_pointer" : 47,
+                    "source_range" : (
+                      {
+                        "line" : 36,
+                        "column" : 3
+                      },
+                      {
+                        "line" : 38,
+                        "column" : 3
+                      }
+                    )
+                  },
+                  {
+                    "name" : "A",
+                    "qual_name" : [
+                      "A",
+                      "main"
+                    ]
+                  },
+                  109,
+                  [
+                    <"FieldDecl" : (
+                      {
+                        "pointer" : 110,
+                        "parent_pointer" : 108,
+                        "source_range" : (
+                          {
+                            "line" : 37,
+                            "column" : 5
+                          },
+                          {
+                            "column" : 9
+                          }
+                        ),
+                        "is_this_declaration_referenced" : true,
+                        "access" : <"Public">
+                      },
+                      {
+                        "name" : "n",
+                        "qual_name" : [
+                          "n",
+                          "A",
+                          "main"
+                        ]
+                      },
+                      {
+                        "type_ptr" : 10
+                      },
+                      {
+                      }
+                    )>,
+                    <"FieldDecl" : (
+                      {
+                        "pointer" : 111,
+                        "parent_pointer" : 108,
+                        "source_range" : (
+                          {
+                            "column" : 5
+                          },
+                          {
+                            "column" : 12
+                          }
+                        ),
+                        "is_this_declaration_referenced" : true,
+                        "access" : <"Public">
+                      },
+                      {
+                        "name" : "m",
+                        "qual_name" : [
+                          "m",
+                          "A",
+                          "main"
+                        ]
+                      },
+                      {
+                        "type_ptr" : 10
+                      },
+                      {
+                      }
+                    )>
+                  ],
+                  {
+                  },
+                  <"TTK_Struct">,
+                  {
+                    "definition_ptr" : 108,
+                    "is_complete_definition" : true
+                  }
+                )>
+              ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 112,
+                "source_range" : (
+                  {
+                    "line" : 39,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 13
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 113,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 12
+                      }
+                    ),
+                    "is_used" : true,
+                    "is_this_declaration_referenced" : true
+                  },
+                  {
+                    "name" : "a",
+                    "qual_name" : [
+                      "a"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 114
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 115,
+                "source_range" : (
+                  {
+                    "line" : 40,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 9
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 116,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 5
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 117,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 114
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 113,
+                          "name" : {
+                            "name" : "a",
+                            "qual_name" : [
+                              "a"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 114
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    },
+                    "value_kind" : <"LValue">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "n",
+                      "qual_name" : [
+                        "n",
+                        "A",
+                        "main"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 110,
+                      "name" : {
+                        "name" : "n",
+                        "qual_name" : [
+                          "n",
+                          "A",
+                          "main"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 10
+                      }
+                    }
+                  }
+                )>,
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 118,
+                    "source_range" : (
+                      {
+                        "column" : 9
+                      },
+                      {
+                        "column" : 9
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "42"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 119,
+                "source_range" : (
+                  {
+                    "line" : 41,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 9
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 120,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 5
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 121,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 114
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 113,
+                          "name" : {
+                            "name" : "a",
+                            "qual_name" : [
+                              "a"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 114
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    },
+                    "value_kind" : <"LValue">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "m",
+                      "qual_name" : [
+                        "m",
+                        "A",
+                        "main"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 111,
+                      "name" : {
+                        "name" : "m",
+                        "qual_name" : [
+                          "m",
+                          "A",
+                          "main"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 10
+                      }
+                    }
+                  }
+                )>,
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 122,
+                    "source_range" : (
+                      {
+                        "column" : 9
+                      },
+                      {
+                        "column" : 9
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "99"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 123,
+                "source_range" : (
+                  {
+                    "line" : 43,
+                    "column" : 3
+                  },
+                  {
+                    "line" : 46,
+                    "column" : 9
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"RecordDecl" : (
+                  {
+                    "pointer" : 124,
+                    "parent_pointer" : 47,
+                    "source_range" : (
+                      {
+                        "line" : 43,
+                        "column" : 3
+                      },
+                      {
+                        "line" : 46,
+                        "column" : 3
+                      }
+                    )
+                  },
+                  {
+                    "name" : "",
+                    "qual_name" : [
+                      "anonymous_struct_sample/types/record.c:43:3",
+                      "main"
+                    ]
+                  },
+                  125,
+                  [
+                    <"FieldDecl" : (
+                      {
+                        "pointer" : 126,
+                        "parent_pointer" : 124,
+                        "source_range" : (
+                          {
+                            "line" : 44,
+                            "column" : 5
+                          },
+                          {
+                            "column" : 9
+                          }
+                        ),
+                        "is_this_declaration_referenced" : true,
+                        "access" : <"Public">
+                      },
+                      {
+                        "name" : "id",
+                        "qual_name" : [
+                          "id",
+                          "anonymous_struct_sample/types/record.c:43:3",
+                          "main"
+                        ]
+                      },
+                      {
+                        "type_ptr" : 10
+                      },
+                      {
+                      }
+                    )>,
+                    <"FieldDecl" : (
+                      {
+                        "pointer" : 127,
+                        "parent_pointer" : 124,
+                        "source_range" : (
+                          {
+                            "line" : 45,
+                            "column" : 5
+                          },
+                          {
+                            "column" : 18
+                          }
+                        ),
+                        "is_this_declaration_referenced" : true,
+                        "access" : <"Public">
+                      },
+                      {
+                        "name" : "age",
+                        "qual_name" : [
+                          "age",
+                          "anonymous_struct_sample/types/record.c:43:3",
+                          "main"
+                        ]
+                      },
+                      {
+                        "type_ptr" : 23
+                      },
+                      {
+                      }
+                    )>
+                  ],
+                  {
+                  },
+                  <"TTK_Struct">,
+                  {
+                    "definition_ptr" : 124,
+                    "is_complete_definition" : true
+                  }
+                )>,
+                <"VarDecl" : (
+                  {
+                    "pointer" : 128,
+                    "source_range" : (
+                      {
+                        "line" : 43,
+                        "column" : 3
+                      },
+                      {
+                        "line" : 46,
+                        "column" : 5
+                      }
+                    ),
+                    "is_used" : true,
+                    "is_this_declaration_referenced" : true
+                  },
+                  {
+                    "name" : "user",
+                    "qual_name" : [
+                      "user"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 129
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 130,
+                "source_range" : (
+                  {
+                    "line" : 47,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 13
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 131,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 8
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 132,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 129
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 128,
+                          "name" : {
+                            "name" : "user",
+                            "qual_name" : [
+                              "user"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 129
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    },
+                    "value_kind" : <"LValue">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "id",
+                      "qual_name" : [
+                        "id",
+                        "anonymous_struct_sample/types/record.c:43:3",
+                        "main"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 126,
+                      "name" : {
+                        "name" : "id",
+                        "qual_name" : [
+                          "id",
+                          "anonymous_struct_sample/types/record.c:43:3",
+                          "main"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 10
+                      }
+                    }
+                  }
+                )>,
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 133,
+                    "source_range" : (
+                      {
+                        "column" : 13
+                      },
+                      {
+                        "column" : 13
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "0"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 134,
+                "source_range" : (
+                  {
+                    "line" : 48,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 14
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 135,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 8
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 136,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 129
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 128,
+                          "name" : {
+                            "name" : "user",
+                            "qual_name" : [
+                              "user"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 129
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    },
+                    "value_kind" : <"LValue">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "age",
+                      "qual_name" : [
+                        "age",
+                        "anonymous_struct_sample/types/record.c:43:3",
+                        "main"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 127,
+                      "name" : {
+                        "name" : "age",
+                        "qual_name" : [
+                          "age",
+                          "anonymous_struct_sample/types/record.c:43:3",
+                          "main"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 23
+                      }
+                    }
+                  }
+                )>,
+                <"ImplicitCastExpr" : (
+                  {
+                    "pointer" : 137,
+                    "source_range" : (
+                      {
+                        "column" : 14
+                      },
+                      {
+                        "column" : 14
+                      }
+                    )
+                  },
+                  [
+                    <"IntegerLiteral" : (
+                      {
+                        "pointer" : 138,
+                        "source_range" : (
+                          {
+                            "column" : 14
+                          },
+                          {
+                            "column" : 14
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "20"
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    }
+                  },
+                  {
+                    "cast_kind" : <"IntegralCast">,
+                    "base_path" : [
+                    ]
+                  },
+                  false
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 23
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
             )>
           ]
         )>
@@ -2923,7 +3772,7 @@
     )>,
     <"TypedefDecl" : (
       {
-        "pointer" : 107,
+        "pointer" : 139,
         "source_range" : (
           {
           },
@@ -2938,7 +3787,7 @@
           "instancetype"
         ]
       },
-      108,
+      140,
       {
       }
     )>
@@ -2958,31 +3807,31 @@
     "types" : [
       <"BuiltinType" : (
         {
-          "pointer" : 109
+          "pointer" : 141
         },
         <"Void">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 110
+          "pointer" : 142
         },
         <"Bool">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 111
+          "pointer" : 143
         },
         <"Char_S">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 112
+          "pointer" : 144
         },
         <"SChar">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 113
+          "pointer" : 145
         },
         <"Short">
       )>,
@@ -2994,25 +3843,25 @@
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 114
+          "pointer" : 146
         },
         <"Long">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 115
+          "pointer" : 147
         },
         <"LongLong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 116
+          "pointer" : 148
         },
         <"UChar">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 117
+          "pointer" : 149
         },
         <"UShort">
       )>,
@@ -3024,329 +3873,329 @@
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 118
+          "pointer" : 150
         },
         <"ULong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 119
+          "pointer" : 151
         },
         <"ULongLong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 120
+          "pointer" : 152
         },
         <"Float">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 121
+          "pointer" : 153
         },
         <"Double">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 122
+          "pointer" : 154
         },
         <"LongDouble">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 123
+          "pointer" : 155
         },
         <"Float128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 124
+          "pointer" : 156
         },
         <"Float16">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 125
+          "pointer" : 157
         },
         <"ShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 126
+          "pointer" : 158
         },
         <"Accum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 127
+          "pointer" : 159
         },
         <"LongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 128
+          "pointer" : 160
         },
         <"UShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 129
+          "pointer" : 161
         },
         <"UAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 130
+          "pointer" : 162
         },
         <"ULongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 131
+          "pointer" : 163
         },
         <"ShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 132
+          "pointer" : 164
         },
         <"Fract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 133
+          "pointer" : 165
         },
         <"LongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 134
+          "pointer" : 166
         },
         <"UShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 135
+          "pointer" : 167
         },
         <"UFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 136
+          "pointer" : 168
         },
         <"ULongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 137
+          "pointer" : 169
         },
         <"SatShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 138
+          "pointer" : 170
         },
         <"SatAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 139
+          "pointer" : 171
         },
         <"SatLongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 140
+          "pointer" : 172
         },
         <"SatUShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 141
+          "pointer" : 173
         },
         <"SatUAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 142
+          "pointer" : 174
         },
         <"SatULongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 143
+          "pointer" : 175
         },
         <"SatShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 144
+          "pointer" : 176
         },
         <"SatFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 145
+          "pointer" : 177
         },
         <"SatLongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 146
+          "pointer" : 178
         },
         <"SatUShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 147
+          "pointer" : 179
         },
         <"SatUFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 148
+          "pointer" : 180
         },
         <"SatULongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 149
+          "pointer" : 181
         },
         <"Int128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 150
+          "pointer" : 182
         },
         <"UInt128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 151
+          "pointer" : 183
         },
         <"WChar_S">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 152
+          "pointer" : 184
         },
         <"Char8">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 153
+          "pointer" : 185
         },
         <"Dependent">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 154
+          "pointer" : 186
         },
         <"Overload">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 155
+          "pointer" : 187
         },
         <"BoundMember">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 156
+          "pointer" : 188
         },
         <"PseudoObject">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 157
+          "pointer" : 189
         },
         <"UnknownAny">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 158
+          "pointer" : 190
         },
         <"ARCUnbridgedCast">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 159
+          "pointer" : 191
         },
         <"BuiltinFn">
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 160
+          "pointer" : 192
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 161
+          "pointer" : 193
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 162
+          "pointer" : 194
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 163
+          "pointer" : 195
         }
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 164
+          "pointer" : 196
         },
         <"ObjCId">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 165
+          "pointer" : 197
         },
         <"ObjCClass">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 166
+          "pointer" : 198
         },
         <"ObjCSel">
       )>,
       <"PointerType" : (
         {
-          "pointer" : 167
+          "pointer" : 199
         },
         {
-          "type_ptr" : 109
+          "type_ptr" : 141
         }
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 168
+          "pointer" : 200
         },
         <"NullPtr">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 169
+          "pointer" : 201
         },
         <"Half">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 170
+          "pointer" : 202
         },
         <"BFloat16">
       )>,
       <"RecordType" : (
         {
-          "pointer" : 171
+          "pointer" : 203
         },
-        172
+        204
       )>,
       <"PointerType" : (
         {
-          "pointer" : 173
+          "pointer" : 205
         },
         {
           "type_ptr" : 10,
@@ -3355,34 +4204,34 @@
       )>,
       <"PointerType" : (
         {
-          "pointer" : 174
+          "pointer" : 206
         },
         {
-          "type_ptr" : 111,
+          "type_ptr" : 143,
           "is_const" : true
         }
       )>,
       <"PointerType" : (
         {
-          "pointer" : 175
+          "pointer" : 207
         },
         {
-          "type_ptr" : 111
+          "type_ptr" : 143
         }
       )>,
       <"RecordType" : (
         {
-          "pointer" : 176
+          "pointer" : 208
         },
-        177
+        209
       )>,
       <"ConstantArrayType" : (
         {
-          "pointer" : 178
+          "pointer" : 210
         },
         {
           "element_type" : {
-            "type_ptr" : 176
+            "type_ptr" : 208
           },
           "stride" : 24
         },
@@ -3402,7 +4251,7 @@
       )>,
       <"ElaboratedType" : (
         {
-          "pointer" : 179,
+          "pointer" : 211,
           "desugared_type" : 13
         }
       )>,
@@ -3432,10 +4281,10 @@
       )>,
       <"PointerType" : (
         {
-          "pointer" : 180
+          "pointer" : 212
         },
         {
-          "type_ptr" : 175
+          "type_ptr" : 207
         }
       )>,
       <"ElaboratedType" : (
@@ -3451,7 +4300,7 @@
         },
         {
           "child_type" : {
-            "type_ptr" : 179
+            "type_ptr" : 211
           },
           "decl_ptr" : 16
         }
@@ -3462,44 +4311,68 @@
           "desugared_type" : 21
         }
       )>,
+      <"RecordType" : (
+        {
+          "pointer" : 109
+        },
+        108
+      )>,
+      <"ElaboratedType" : (
+        {
+          "pointer" : 114,
+          "desugared_type" : 109
+        }
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 125
+        },
+        124
+      )>,
+      <"ElaboratedType" : (
+        {
+          "pointer" : 129,
+          "desugared_type" : 125
+        }
+      )>,
       <"ObjCObjectType" : (
         {
-          "pointer" : 181
+          "pointer" : 213
         },
         {
-          "base_type" : 164
+          "base_type" : 196
         }
       )>,
       <"ObjCObjectPointerType" : (
         {
-          "pointer" : 182
+          "pointer" : 214
         },
         {
-          "type_ptr" : 181
+          "type_ptr" : 213
         }
       )>,
       <"TypedefType" : (
         {
-          "pointer" : 183,
-          "desugared_type" : 182
+          "pointer" : 215,
+          "desugared_type" : 214
         },
         {
           "child_type" : {
-            "type_ptr" : 182
+            "type_ptr" : 214
           },
-          "decl_ptr" : 184
+          "decl_ptr" : 216
         }
       )>,
       <"TypedefType" : (
         {
-          "pointer" : 108,
-          "desugared_type" : 182
+          "pointer" : 140,
+          "desugared_type" : 214
         },
         {
           "child_type" : {
-            "type_ptr" : 183
+            "type_ptr" : 215
           },
-          "decl_ptr" : 107
+          "decl_ptr" : 139
         }
       )>,
       <"NoneType" : (

--- a/sample/types/record.c.yojson
+++ b/sample/types/record.c.yojson
@@ -318,16 +318,653 @@
       {
       }
     )>,
-    <"FunctionDecl" : (
+    <"RecordDecl" : (
       {
         "pointer" : 18,
+        "parent_pointer" : 1,
         "source_range" : (
           {
             "line" : 10,
             "column" : 1
           },
           {
-            "line" : 21,
+            "column" : 8
+          }
+        )
+      },
+      {
+        "name" : "S3",
+        "qual_name" : [
+          "S3"
+        ]
+      },
+      19,
+      [
+      ],
+      {
+      },
+      <"TTK_Struct">,
+      {
+        "definition_ptr" : 0
+      }
+    )>,
+    <"RecordDecl" : (
+      {
+        "pointer" : 20,
+        "parent_pointer" : 1,
+        "source_range" : (
+          {
+            "line" : 12,
+            "column" : 1
+          },
+          {
+            "line" : 16,
+            "column" : 1
+          }
+        )
+      },
+      {
+        "name" : "X",
+        "qual_name" : [
+          "X"
+        ]
+      },
+      21,
+      [
+        <"FieldDecl" : (
+          {
+            "pointer" : 22,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "line" : 13,
+                "column" : 3
+              },
+              {
+                "column" : 20
+              }
+            ),
+            "is_this_declaration_referenced" : true,
+            "access" : <"Public">
+          },
+          {
+            "name" : "n",
+            "qual_name" : [
+              "n",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 24,
+                "source_range" : (
+                  {
+                    "column" : 20
+                  },
+                  {
+                    "column" : 20
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 25,
+                    "source_range" : (
+                      {
+                        "column" : 20
+                      },
+                      {
+                        "column" : 20
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "16"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>,
+        <"FieldDecl" : (
+          {
+            "pointer" : 26,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "line" : 14,
+                "column" : 3
+              },
+              {
+                "column" : 37
+              }
+            ),
+            "is_this_declaration_referenced" : true,
+            "access" : <"Public">
+          },
+          {
+            "name" : "m",
+            "qual_name" : [
+              "m",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 27,
+                "source_range" : (
+                  {
+                    "column" : 20
+                  },
+                  {
+                    "column" : 37
+                  }
+                )
+              },
+              [
+                <"ConditionalOperator" : (
+                  {
+                    "pointer" : 28,
+                    "source_range" : (
+                      {
+                        "column" : 20
+                      },
+                      {
+                        "column" : 37
+                      }
+                    )
+                  },
+                  [
+                    <"ParenExpr" : (
+                      {
+                        "pointer" : 29,
+                        "source_range" : (
+                          {
+                            "column" : 20
+                          },
+                          {
+                            "column" : 28
+                          }
+                        )
+                      },
+                      [
+                        <"BinaryOperator" : (
+                          {
+                            "pointer" : 30,
+                            "source_range" : (
+                              {
+                                "column" : 21
+                              },
+                              {
+                                "column" : 26
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 31,
+                                "source_range" : (
+                                  {
+                                    "column" : 21
+                                  },
+                                  {
+                                    "column" : 21
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "99"
+                              }
+                            )>,
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 32,
+                                "source_range" : (
+                                  {
+                                    "column" : 26
+                                  },
+                                  {
+                                    "column" : 26
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "42"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "kind" : <"Sub">
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      }
+                    )>,
+                    <"IntegerLiteral" : (
+                      {
+                        "pointer" : 33,
+                        "source_range" : (
+                          {
+                            "column" : 32
+                          },
+                          {
+                            "column" : 32
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "16"
+                      }
+                    )>,
+                    <"IntegerLiteral" : (
+                      {
+                        "pointer" : 34,
+                        "source_range" : (
+                          {
+                            "column" : 37
+                          },
+                          {
+                            "column" : 37
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "32"
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>,
+        <"FieldDecl" : (
+          {
+            "pointer" : 35,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "line" : 15,
+                "column" : 3
+              },
+              {
+                "column" : 20
+              }
+            ),
+            "access" : <"Public">
+          },
+          {
+            "name" : "a",
+            "qual_name" : [
+              "a",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 36,
+                "source_range" : (
+                  {
+                    "column" : 20
+                  },
+                  {
+                    "column" : 20
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 37,
+                    "source_range" : (
+                      {
+                        "column" : 20
+                      },
+                      {
+                        "column" : 20
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "8"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>,
+        <"FieldDecl" : (
+          {
+            "pointer" : 38,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "column" : 3
+              },
+              {
+                "column" : 27
+              }
+            ),
+            "access" : <"Public">
+          },
+          {
+            "name" : "b",
+            "qual_name" : [
+              "b",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 39,
+                "source_range" : (
+                  {
+                    "column" : 27
+                  },
+                  {
+                    "column" : 27
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 40,
+                    "source_range" : (
+                      {
+                        "column" : 27
+                      },
+                      {
+                        "column" : 27
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "8"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>,
+        <"FieldDecl" : (
+          {
+            "pointer" : 41,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "column" : 3
+              },
+              {
+                "column" : 32
+              }
+            ),
+            "access" : <"Public">
+          },
+          {
+            "name" : "__anon_field_4",
+            "qual_name" : [
+              "",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 42,
+                "source_range" : (
+                  {
+                    "column" : 32
+                  },
+                  {
+                    "column" : 32
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 43,
+                    "source_range" : (
+                      {
+                        "column" : 32
+                      },
+                      {
+                        "column" : 32
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "8"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>,
+        <"FieldDecl" : (
+          {
+            "pointer" : 44,
+            "parent_pointer" : 20,
+            "source_range" : (
+              {
+                "column" : 3
+              },
+              {
+                "column" : 39
+              }
+            ),
+            "access" : <"Public">
+          },
+          {
+            "name" : "c",
+            "qual_name" : [
+              "c",
+              "X"
+            ]
+          },
+          {
+            "type_ptr" : 23
+          },
+          {
+            "bit_width_expr" : <"ConstantExpr" : (
+              {
+                "pointer" : 45,
+                "source_range" : (
+                  {
+                    "column" : 39
+                  },
+                  {
+                    "column" : 39
+                  }
+                )
+              },
+              [
+                <"IntegerLiteral" : (
+                  {
+                    "pointer" : 46,
+                    "source_range" : (
+                      {
+                        "column" : 39
+                      },
+                      {
+                        "column" : 39
+                      }
+                    )
+                  },
+                  [
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 10
+                    }
+                  },
+                  {
+                    "is_signed" : true,
+                    "bitwidth" : 32,
+                    "value" : "8"
+                  }
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 10
+                }
+              }
+            )>
+          }
+        )>
+      ],
+      {
+      },
+      <"TTK_Struct">,
+      {
+        "definition_ptr" : 20,
+        "is_complete_definition" : true
+      }
+    )>,
+    <"FunctionDecl" : (
+      {
+        "pointer" : 47,
+        "source_range" : (
+          {
+            "line" : 18,
+            "column" : 1
+          },
+          {
+            "line" : 35,
             "column" : 1
           }
         )
@@ -339,20 +976,20 @@
         ]
       },
       {
-        "type_ptr" : 19
+        "type_ptr" : 48
       },
       {
-        "decl_ptr_with_body" : 18,
+        "decl_ptr_with_body" : 47,
         "body" : <"CompoundStmt" : (
           {
-            "pointer" : 20,
+            "pointer" : 49,
             "source_range" : (
               {
-                "line" : 11,
+                "line" : 19,
                 "column" : 1
               },
               {
-                "line" : 21,
+                "line" : 35,
                 "column" : 1
               }
             )
@@ -360,10 +997,10 @@
           [
             <"DeclStmt" : (
               {
-                "pointer" : 21,
+                "pointer" : 50,
                 "source_range" : (
                   {
-                    "line" : 12,
+                    "line" : 20,
                     "column" : 3
                   },
                   {
@@ -376,7 +1013,7 @@
               [
                 <"VarDecl" : (
                   {
-                    "pointer" : 22,
+                    "pointer" : 51,
                     "source_range" : (
                       {
                         "column" : 3
@@ -395,7 +1032,7 @@
                     ]
                   },
                   {
-                    "type_ptr" : 23
+                    "type_ptr" : 52
                   },
                   {
                   }
@@ -404,10 +1041,10 @@
             )>,
             <"BinaryOperator" : (
               {
-                "pointer" : 24,
+                "pointer" : 53,
                 "source_range" : (
                   {
-                    "line" : 13,
+                    "line" : 21,
                     "column" : 3
                   },
                   {
@@ -418,7 +1055,7 @@
               [
                 <"MemberExpr" : (
                   {
-                    "pointer" : 25,
+                    "pointer" : 54,
                     "source_range" : (
                       {
                         "column" : 3
@@ -431,7 +1068,7 @@
                   [
                     <"DeclRefExpr" : (
                       {
-                        "pointer" : 26,
+                        "pointer" : 55,
                         "source_range" : (
                           {
                             "column" : 3
@@ -445,14 +1082,14 @@
                       ],
                       {
                         "qual_type" : {
-                          "type_ptr" : 23
+                          "type_ptr" : 52
                         },
                         "value_kind" : <"LValue">
                       },
                       {
                         "decl_ref" : {
                           "kind" : <"Var">,
-                          "decl_pointer" : 22,
+                          "decl_pointer" : 51,
                           "name" : {
                             "name" : "s11",
                             "qual_name" : [
@@ -460,7 +1097,7 @@
                             ]
                           },
                           "qual_type" : {
-                            "type_ptr" : 23
+                            "type_ptr" : 52
                           }
                         }
                       }
@@ -499,7 +1136,7 @@
                 )>,
                 <"IntegerLiteral" : (
                   {
-                    "pointer" : 27,
+                    "pointer" : 56,
                     "source_range" : (
                       {
                         "column" : 11
@@ -534,10 +1171,10 @@
             )>,
             <"BinaryOperator" : (
               {
-                "pointer" : 28,
+                "pointer" : 57,
                 "source_range" : (
                   {
-                    "line" : 14,
+                    "line" : 22,
                     "column" : 3
                   },
                   {
@@ -548,7 +1185,7 @@
               [
                 <"MemberExpr" : (
                   {
-                    "pointer" : 29,
+                    "pointer" : 58,
                     "source_range" : (
                       {
                         "column" : 3
@@ -561,7 +1198,7 @@
                   [
                     <"DeclRefExpr" : (
                       {
-                        "pointer" : 30,
+                        "pointer" : 59,
                         "source_range" : (
                           {
                             "column" : 3
@@ -575,14 +1212,14 @@
                       ],
                       {
                         "qual_type" : {
-                          "type_ptr" : 23
+                          "type_ptr" : 52
                         },
                         "value_kind" : <"LValue">
                       },
                       {
                         "decl_ref" : {
                           "kind" : <"Var">,
-                          "decl_pointer" : 22,
+                          "decl_pointer" : 51,
                           "name" : {
                             "name" : "s11",
                             "qual_name" : [
@@ -590,7 +1227,7 @@
                             ]
                           },
                           "qual_type" : {
-                            "type_ptr" : 23
+                            "type_ptr" : 52
                           }
                         }
                       }
@@ -629,7 +1266,7 @@
                 )>,
                 <"IntegerLiteral" : (
                   {
-                    "pointer" : 31,
+                    "pointer" : 60,
                     "source_range" : (
                       {
                         "column" : 11
@@ -664,10 +1301,10 @@
             )>,
             <"DeclStmt" : (
               {
-                "pointer" : 32,
+                "pointer" : 61,
                 "source_range" : (
                   {
-                    "line" : 15,
+                    "line" : 23,
                     "column" : 3
                   },
                   {
@@ -678,7 +1315,7 @@
               [
                 <"InitListExpr" : (
                   {
-                    "pointer" : 33,
+                    "pointer" : 62,
                     "source_range" : (
                       {
                         "column" : 19
@@ -691,7 +1328,7 @@
                   [
                     <"IntegerLiteral" : (
                       {
-                        "pointer" : 34,
+                        "pointer" : 63,
                         "source_range" : (
                           {
                             "column" : 21
@@ -716,7 +1353,7 @@
                     )>,
                     <"IntegerLiteral" : (
                       {
-                        "pointer" : 35,
+                        "pointer" : 64,
                         "source_range" : (
                           {
                             "column" : 24
@@ -742,7 +1379,7 @@
                   ],
                   {
                     "qual_type" : {
-                      "type_ptr" : 23
+                      "type_ptr" : 52
                     }
                   }
                 )>
@@ -750,7 +1387,7 @@
               [
                 <"VarDecl" : (
                   {
-                    "pointer" : 36,
+                    "pointer" : 65,
                     "source_range" : (
                       {
                         "column" : 3
@@ -767,12 +1404,12 @@
                     ]
                   },
                   {
-                    "type_ptr" : 23
+                    "type_ptr" : 52
                   },
                   {
                     "init_expr" : <"InitListExpr" : (
                       {
-                        "pointer" : 33,
+                        "pointer" : 62,
                         "source_range" : (
                           {
                             "column" : 19
@@ -785,7 +1422,7 @@
                       [
                         <"IntegerLiteral" : (
                           {
-                            "pointer" : 34,
+                            "pointer" : 63,
                             "source_range" : (
                               {
                                 "column" : 21
@@ -810,7 +1447,7 @@
                         )>,
                         <"IntegerLiteral" : (
                           {
-                            "pointer" : 35,
+                            "pointer" : 64,
                             "source_range" : (
                               {
                                 "column" : 24
@@ -836,7 +1473,7 @@
                       ],
                       {
                         "qual_type" : {
-                          "type_ptr" : 23
+                          "type_ptr" : 52
                         }
                       }
                     )>
@@ -846,10 +1483,10 @@
             )>,
             <"DeclStmt" : (
               {
-                "pointer" : 37,
+                "pointer" : 66,
                 "source_range" : (
                   {
-                    "line" : 17,
+                    "line" : 25,
                     "column" : 3
                   },
                   {
@@ -862,7 +1499,7 @@
               [
                 <"VarDecl" : (
                   {
-                    "pointer" : 38,
+                    "pointer" : 67,
                     "source_range" : (
                       {
                         "column" : 3
@@ -890,10 +1527,10 @@
             )>,
             <"BinaryOperator" : (
               {
-                "pointer" : 39,
+                "pointer" : 68,
                 "source_range" : (
                   {
-                    "line" : 18,
+                    "line" : 26,
                     "column" : 3
                   },
                   {
@@ -904,7 +1541,7 @@
               [
                 <"MemberExpr" : (
                   {
-                    "pointer" : 40,
+                    "pointer" : 69,
                     "source_range" : (
                       {
                         "column" : 3
@@ -917,7 +1554,7 @@
                   [
                     <"DeclRefExpr" : (
                       {
-                        "pointer" : 41,
+                        "pointer" : 70,
                         "source_range" : (
                           {
                             "column" : 3
@@ -938,7 +1575,7 @@
                       {
                         "decl_ref" : {
                           "kind" : <"Var">,
-                          "decl_pointer" : 38,
+                          "decl_pointer" : 67,
                           "name" : {
                             "name" : "s21",
                             "qual_name" : [
@@ -985,7 +1622,7 @@
                 )>,
                 <"IntegerLiteral" : (
                   {
-                    "pointer" : 42,
+                    "pointer" : 71,
                     "source_range" : (
                       {
                         "column" : 11
@@ -1020,10 +1657,10 @@
             )>,
             <"BinaryOperator" : (
               {
-                "pointer" : 43,
+                "pointer" : 72,
                 "source_range" : (
                   {
-                    "line" : 19,
+                    "line" : 27,
                     "column" : 3
                   },
                   {
@@ -1034,7 +1671,7 @@
               [
                 <"MemberExpr" : (
                   {
-                    "pointer" : 44,
+                    "pointer" : 73,
                     "source_range" : (
                       {
                         "column" : 3
@@ -1047,7 +1684,7 @@
                   [
                     <"DeclRefExpr" : (
                       {
-                        "pointer" : 45,
+                        "pointer" : 74,
                         "source_range" : (
                           {
                             "column" : 3
@@ -1068,7 +1705,7 @@
                       {
                         "decl_ref" : {
                           "kind" : <"Var">,
-                          "decl_pointer" : 38,
+                          "decl_pointer" : 67,
                           "name" : {
                             "name" : "s21",
                             "qual_name" : [
@@ -1115,7 +1752,7 @@
                 )>,
                 <"IntegerLiteral" : (
                   {
-                    "pointer" : 46,
+                    "pointer" : 75,
                     "source_range" : (
                       {
                         "column" : 11
@@ -1150,10 +1787,10 @@
             )>,
             <"DeclStmt" : (
               {
-                "pointer" : 47,
+                "pointer" : 76,
                 "source_range" : (
                   {
-                    "line" : 20,
+                    "line" : 28,
                     "column" : 3
                   },
                   {
@@ -1164,7 +1801,7 @@
               [
                 <"InitListExpr" : (
                   {
-                    "pointer" : 48,
+                    "pointer" : 77,
                     "source_range" : (
                       {
                         "column" : 12
@@ -1177,7 +1814,7 @@
                   [
                     <"IntegerLiteral" : (
                       {
-                        "pointer" : 49,
+                        "pointer" : 78,
                         "source_range" : (
                           {
                             "column" : 14
@@ -1202,7 +1839,7 @@
                     )>,
                     <"IntegerLiteral" : (
                       {
-                        "pointer" : 50,
+                        "pointer" : 79,
                         "source_range" : (
                           {
                             "column" : 17
@@ -1236,7 +1873,7 @@
               [
                 <"VarDecl" : (
                   {
-                    "pointer" : 51,
+                    "pointer" : 80,
                     "source_range" : (
                       {
                         "column" : 3
@@ -1258,7 +1895,7 @@
                   {
                     "init_expr" : <"InitListExpr" : (
                       {
-                        "pointer" : 48,
+                        "pointer" : 77,
                         "source_range" : (
                           {
                             "column" : 12
@@ -1271,7 +1908,7 @@
                       [
                         <"IntegerLiteral" : (
                           {
-                            "pointer" : 49,
+                            "pointer" : 78,
                             "source_range" : (
                               {
                                 "column" : 14
@@ -1296,7 +1933,7 @@
                         )>,
                         <"IntegerLiteral" : (
                           {
-                            "pointer" : 50,
+                            "pointer" : 79,
                             "source_range" : (
                               {
                                 "column" : 17
@@ -1329,6 +1966,956 @@
                   }
                 )>
               ]
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 81,
+                "source_range" : (
+                  {
+                    "line" : 30,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 14
+                  }
+                )
+              },
+              [
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 82,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 12
+                      }
+                    ),
+                    "is_used" : true,
+                    "is_this_declaration_referenced" : true
+                  },
+                  {
+                    "name" : "x1",
+                    "qual_name" : [
+                      "x1"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 83
+                  },
+                  {
+                  }
+                )>
+              ]
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 84,
+                "source_range" : (
+                  {
+                    "line" : 31,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 10
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 85,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 6
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 86,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 83
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 82,
+                          "name" : {
+                            "name" : "x1",
+                            "qual_name" : [
+                              "x1"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 83
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    },
+                    "value_kind" : <"LValue">,
+                    "object_kind" : <"BitField">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "n",
+                      "qual_name" : [
+                        "n",
+                        "X"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 22,
+                      "name" : {
+                        "name" : "n",
+                        "qual_name" : [
+                          "n",
+                          "X"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 23
+                      }
+                    }
+                  }
+                )>,
+                <"ImplicitCastExpr" : (
+                  {
+                    "pointer" : 87,
+                    "source_range" : (
+                      {
+                        "column" : 10
+                      },
+                      {
+                        "column" : 10
+                      }
+                    )
+                  },
+                  [
+                    <"IntegerLiteral" : (
+                      {
+                        "pointer" : 88,
+                        "source_range" : (
+                          {
+                            "column" : 10
+                          },
+                          {
+                            "column" : 10
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "0"
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    }
+                  },
+                  {
+                    "cast_kind" : <"IntegralCast">,
+                    "base_path" : [
+                    ]
+                  },
+                  false
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 23
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
+            )>,
+            <"BinaryOperator" : (
+              {
+                "pointer" : 89,
+                "source_range" : (
+                  {
+                    "line" : 32,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 10
+                  }
+                )
+              },
+              [
+                <"MemberExpr" : (
+                  {
+                    "pointer" : 90,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 6
+                      }
+                    )
+                  },
+                  [
+                    <"DeclRefExpr" : (
+                      {
+                        "pointer" : 91,
+                        "source_range" : (
+                          {
+                            "column" : 3
+                          },
+                          {
+                            "column" : 3
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 83
+                        },
+                        "value_kind" : <"LValue">
+                      },
+                      {
+                        "decl_ref" : {
+                          "kind" : <"Var">,
+                          "decl_pointer" : 82,
+                          "name" : {
+                            "name" : "x1",
+                            "qual_name" : [
+                              "x1"
+                            ]
+                          },
+                          "qual_type" : {
+                            "type_ptr" : 83
+                          }
+                        }
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    },
+                    "value_kind" : <"LValue">,
+                    "object_kind" : <"BitField">
+                  },
+                  {
+                    "performs_virtual_dispatch" : true,
+                    "name" : {
+                      "name" : "m",
+                      "qual_name" : [
+                        "m",
+                        "X"
+                      ]
+                    },
+                    "decl_ref" : {
+                      "kind" : <"Field">,
+                      "decl_pointer" : 26,
+                      "name" : {
+                        "name" : "m",
+                        "qual_name" : [
+                          "m",
+                          "X"
+                        ]
+                      },
+                      "qual_type" : {
+                        "type_ptr" : 23
+                      }
+                    }
+                  }
+                )>,
+                <"ImplicitCastExpr" : (
+                  {
+                    "pointer" : 92,
+                    "source_range" : (
+                      {
+                        "column" : 10
+                      },
+                      {
+                        "column" : 10
+                      }
+                    )
+                  },
+                  [
+                    <"IntegerLiteral" : (
+                      {
+                        "pointer" : 93,
+                        "source_range" : (
+                          {
+                            "column" : 10
+                          },
+                          {
+                            "column" : 10
+                          }
+                        )
+                      },
+                      [
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 10
+                        }
+                      },
+                      {
+                        "is_signed" : true,
+                        "bitwidth" : 32,
+                        "value" : "1"
+                      }
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 23
+                    }
+                  },
+                  {
+                    "cast_kind" : <"IntegralCast">,
+                    "base_path" : [
+                    ]
+                  },
+                  false
+                )>
+              ],
+              {
+                "qual_type" : {
+                  "type_ptr" : 23
+                }
+              },
+              {
+                "kind" : <"Assign">
+              }
+            )>,
+            <"DeclStmt" : (
+              {
+                "pointer" : 94,
+                "source_range" : (
+                  {
+                    "line" : 34,
+                    "column" : 3
+                  },
+                  {
+                    "column" : 34
+                  }
+                )
+              },
+              [
+                <"InitListExpr" : (
+                  {
+                    "pointer" : 95,
+                    "source_range" : (
+                      {
+                        "column" : 17
+                      },
+                      {
+                        "column" : 33
+                      }
+                    )
+                  },
+                  [
+                    <"ImplicitCastExpr" : (
+                      {
+                        "pointer" : 96,
+                        "source_range" : (
+                          {
+                            "column" : 19
+                          },
+                          {
+                            "column" : 19
+                          }
+                        )
+                      },
+                      [
+                        <"IntegerLiteral" : (
+                          {
+                            "pointer" : 97,
+                            "source_range" : (
+                              {
+                                "column" : 19
+                              },
+                              {
+                                "column" : 19
+                              }
+                            )
+                          },
+                          [
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "is_signed" : true,
+                            "bitwidth" : 32,
+                            "value" : "0"
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 23
+                        }
+                      },
+                      {
+                        "cast_kind" : <"IntegralCast">,
+                        "base_path" : [
+                        ]
+                      },
+                      false
+                    )>,
+                    <"ImplicitCastExpr" : (
+                      {
+                        "pointer" : 98,
+                        "source_range" : (
+                          {
+                            "column" : 22
+                          },
+                          {
+                            "column" : 22
+                          }
+                        )
+                      },
+                      [
+                        <"IntegerLiteral" : (
+                          {
+                            "pointer" : 99,
+                            "source_range" : (
+                              {
+                                "column" : 22
+                              },
+                              {
+                                "column" : 22
+                              }
+                            )
+                          },
+                          [
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "is_signed" : true,
+                            "bitwidth" : 32,
+                            "value" : "0"
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 23
+                        }
+                      },
+                      {
+                        "cast_kind" : <"IntegralCast">,
+                        "base_path" : [
+                        ]
+                      },
+                      false
+                    )>,
+                    <"ImplicitCastExpr" : (
+                      {
+                        "pointer" : 100,
+                        "source_range" : (
+                          {
+                            "column" : 25
+                          },
+                          {
+                            "column" : 25
+                          }
+                        )
+                      },
+                      [
+                        <"IntegerLiteral" : (
+                          {
+                            "pointer" : 101,
+                            "source_range" : (
+                              {
+                                "column" : 25
+                              },
+                              {
+                                "column" : 25
+                              }
+                            )
+                          },
+                          [
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "is_signed" : true,
+                            "bitwidth" : 32,
+                            "value" : "0"
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 23
+                        }
+                      },
+                      {
+                        "cast_kind" : <"IntegralCast">,
+                        "base_path" : [
+                        ]
+                      },
+                      false
+                    )>,
+                    <"ImplicitCastExpr" : (
+                      {
+                        "pointer" : 102,
+                        "source_range" : (
+                          {
+                            "column" : 28
+                          },
+                          {
+                            "column" : 28
+                          }
+                        )
+                      },
+                      [
+                        <"IntegerLiteral" : (
+                          {
+                            "pointer" : 103,
+                            "source_range" : (
+                              {
+                                "column" : 28
+                              },
+                              {
+                                "column" : 28
+                              }
+                            )
+                          },
+                          [
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "is_signed" : true,
+                            "bitwidth" : 32,
+                            "value" : "0"
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 23
+                        }
+                      },
+                      {
+                        "cast_kind" : <"IntegralCast">,
+                        "base_path" : [
+                        ]
+                      },
+                      false
+                    )>,
+                    <"ImplicitCastExpr" : (
+                      {
+                        "pointer" : 104,
+                        "source_range" : (
+                          {
+                            "column" : 31
+                          },
+                          {
+                            "column" : 31
+                          }
+                        )
+                      },
+                      [
+                        <"IntegerLiteral" : (
+                          {
+                            "pointer" : 105,
+                            "source_range" : (
+                              {
+                                "column" : 31
+                              },
+                              {
+                                "column" : 31
+                              }
+                            )
+                          },
+                          [
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 10
+                            }
+                          },
+                          {
+                            "is_signed" : true,
+                            "bitwidth" : 32,
+                            "value" : "0"
+                          }
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 23
+                        }
+                      },
+                      {
+                        "cast_kind" : <"IntegralCast">,
+                        "base_path" : [
+                        ]
+                      },
+                      false
+                    )>
+                  ],
+                  {
+                    "qual_type" : {
+                      "type_ptr" : 83
+                    }
+                  }
+                )>
+              ],
+              [
+                <"VarDecl" : (
+                  {
+                    "pointer" : 106,
+                    "source_range" : (
+                      {
+                        "column" : 3
+                      },
+                      {
+                        "column" : 33
+                      }
+                    )
+                  },
+                  {
+                    "name" : "x2",
+                    "qual_name" : [
+                      "x2"
+                    ]
+                  },
+                  {
+                    "type_ptr" : 83
+                  },
+                  {
+                    "init_expr" : <"InitListExpr" : (
+                      {
+                        "pointer" : 95,
+                        "source_range" : (
+                          {
+                            "column" : 17
+                          },
+                          {
+                            "column" : 33
+                          }
+                        )
+                      },
+                      [
+                        <"ImplicitCastExpr" : (
+                          {
+                            "pointer" : 96,
+                            "source_range" : (
+                              {
+                                "column" : 19
+                              },
+                              {
+                                "column" : 19
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 97,
+                                "source_range" : (
+                                  {
+                                    "column" : 19
+                                  },
+                                  {
+                                    "column" : 19
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "0"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 23
+                            }
+                          },
+                          {
+                            "cast_kind" : <"IntegralCast">,
+                            "base_path" : [
+                            ]
+                          },
+                          false
+                        )>,
+                        <"ImplicitCastExpr" : (
+                          {
+                            "pointer" : 98,
+                            "source_range" : (
+                              {
+                                "column" : 22
+                              },
+                              {
+                                "column" : 22
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 99,
+                                "source_range" : (
+                                  {
+                                    "column" : 22
+                                  },
+                                  {
+                                    "column" : 22
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "0"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 23
+                            }
+                          },
+                          {
+                            "cast_kind" : <"IntegralCast">,
+                            "base_path" : [
+                            ]
+                          },
+                          false
+                        )>,
+                        <"ImplicitCastExpr" : (
+                          {
+                            "pointer" : 100,
+                            "source_range" : (
+                              {
+                                "column" : 25
+                              },
+                              {
+                                "column" : 25
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 101,
+                                "source_range" : (
+                                  {
+                                    "column" : 25
+                                  },
+                                  {
+                                    "column" : 25
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "0"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 23
+                            }
+                          },
+                          {
+                            "cast_kind" : <"IntegralCast">,
+                            "base_path" : [
+                            ]
+                          },
+                          false
+                        )>,
+                        <"ImplicitCastExpr" : (
+                          {
+                            "pointer" : 102,
+                            "source_range" : (
+                              {
+                                "column" : 28
+                              },
+                              {
+                                "column" : 28
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 103,
+                                "source_range" : (
+                                  {
+                                    "column" : 28
+                                  },
+                                  {
+                                    "column" : 28
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "0"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 23
+                            }
+                          },
+                          {
+                            "cast_kind" : <"IntegralCast">,
+                            "base_path" : [
+                            ]
+                          },
+                          false
+                        )>,
+                        <"ImplicitCastExpr" : (
+                          {
+                            "pointer" : 104,
+                            "source_range" : (
+                              {
+                                "column" : 31
+                              },
+                              {
+                                "column" : 31
+                              }
+                            )
+                          },
+                          [
+                            <"IntegerLiteral" : (
+                              {
+                                "pointer" : 105,
+                                "source_range" : (
+                                  {
+                                    "column" : 31
+                                  },
+                                  {
+                                    "column" : 31
+                                  }
+                                )
+                              },
+                              [
+                              ],
+                              {
+                                "qual_type" : {
+                                  "type_ptr" : 10
+                                }
+                              },
+                              {
+                                "is_signed" : true,
+                                "bitwidth" : 32,
+                                "value" : "0"
+                              }
+                            )>
+                          ],
+                          {
+                            "qual_type" : {
+                              "type_ptr" : 23
+                            }
+                          },
+                          {
+                            "cast_kind" : <"IntegralCast">,
+                            "base_path" : [
+                            ]
+                          },
+                          false
+                        )>
+                      ],
+                      {
+                        "qual_type" : {
+                          "type_ptr" : 83
+                        }
+                      }
+                    )>
+                  }
+                )>
+              ]
             )>
           ]
         )>
@@ -1336,7 +2923,7 @@
     )>,
     <"TypedefDecl" : (
       {
-        "pointer" : 52,
+        "pointer" : 107,
         "source_range" : (
           {
           },
@@ -1351,7 +2938,7 @@
           "instancetype"
         ]
       },
-      53,
+      108,
       {
       }
     )>
@@ -1371,31 +2958,31 @@
     "types" : [
       <"BuiltinType" : (
         {
-          "pointer" : 54
+          "pointer" : 109
         },
         <"Void">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 55
+          "pointer" : 110
         },
         <"Bool">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 56
+          "pointer" : 111
         },
         <"Char_S">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 57
+          "pointer" : 112
         },
         <"SChar">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 58
+          "pointer" : 113
         },
         <"Short">
       )>,
@@ -1407,359 +2994,359 @@
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 59
+          "pointer" : 114
         },
         <"Long">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 60
+          "pointer" : 115
         },
         <"LongLong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 61
+          "pointer" : 116
         },
         <"UChar">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 62
+          "pointer" : 117
         },
         <"UShort">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 63
+          "pointer" : 23
         },
         <"UInt">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 64
+          "pointer" : 118
         },
         <"ULong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 65
+          "pointer" : 119
         },
         <"ULongLong">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 66
+          "pointer" : 120
         },
         <"Float">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 67
+          "pointer" : 121
         },
         <"Double">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 68
+          "pointer" : 122
         },
         <"LongDouble">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 69
+          "pointer" : 123
         },
         <"Float128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 70
+          "pointer" : 124
         },
         <"Float16">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 71
+          "pointer" : 125
         },
         <"ShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 72
+          "pointer" : 126
         },
         <"Accum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 73
+          "pointer" : 127
         },
         <"LongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 74
+          "pointer" : 128
         },
         <"UShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 75
+          "pointer" : 129
         },
         <"UAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 76
+          "pointer" : 130
         },
         <"ULongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 77
+          "pointer" : 131
         },
         <"ShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 78
+          "pointer" : 132
         },
         <"Fract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 79
+          "pointer" : 133
         },
         <"LongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 80
+          "pointer" : 134
         },
         <"UShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 81
+          "pointer" : 135
         },
         <"UFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 82
+          "pointer" : 136
         },
         <"ULongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 83
+          "pointer" : 137
         },
         <"SatShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 84
+          "pointer" : 138
         },
         <"SatAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 85
+          "pointer" : 139
         },
         <"SatLongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 86
+          "pointer" : 140
         },
         <"SatUShortAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 87
+          "pointer" : 141
         },
         <"SatUAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 88
+          "pointer" : 142
         },
         <"SatULongAccum">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 89
+          "pointer" : 143
         },
         <"SatShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 90
+          "pointer" : 144
         },
         <"SatFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 91
+          "pointer" : 145
         },
         <"SatLongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 92
+          "pointer" : 146
         },
         <"SatUShortFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 93
+          "pointer" : 147
         },
         <"SatUFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 94
+          "pointer" : 148
         },
         <"SatULongFract">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 95
+          "pointer" : 149
         },
         <"Int128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 96
+          "pointer" : 150
         },
         <"UInt128">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 97
+          "pointer" : 151
         },
         <"WChar_S">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 98
+          "pointer" : 152
         },
         <"Char8">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 99
+          "pointer" : 153
         },
         <"Dependent">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 100
+          "pointer" : 154
         },
         <"Overload">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 101
+          "pointer" : 155
         },
         <"BoundMember">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 102
+          "pointer" : 156
         },
         <"PseudoObject">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 103
+          "pointer" : 157
         },
         <"UnknownAny">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 104
+          "pointer" : 158
         },
         <"ARCUnbridgedCast">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 105
+          "pointer" : 159
         },
         <"BuiltinFn">
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 106
+          "pointer" : 160
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 107
+          "pointer" : 161
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 108
+          "pointer" : 162
         }
       )>,
       <"ComplexType" : (
         {
-          "pointer" : 109
+          "pointer" : 163
         }
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 110
+          "pointer" : 164
         },
         <"ObjCId">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 111
+          "pointer" : 165
         },
         <"ObjCClass">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 112
+          "pointer" : 166
         },
         <"ObjCSel">
       )>,
       <"PointerType" : (
         {
-          "pointer" : 113
+          "pointer" : 167
         },
         {
-          "type_ptr" : 54
+          "type_ptr" : 109
         }
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 114
+          "pointer" : 168
         },
         <"NullPtr">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 115
+          "pointer" : 169
         },
         <"Half">
       )>,
       <"BuiltinType" : (
         {
-          "pointer" : 116
+          "pointer" : 170
         },
         <"BFloat16">
       )>,
       <"RecordType" : (
         {
-          "pointer" : 117
+          "pointer" : 171
         },
-        118
+        172
       )>,
       <"PointerType" : (
         {
-          "pointer" : 119
+          "pointer" : 173
         },
         {
           "type_ptr" : 10,
@@ -1768,34 +3355,34 @@
       )>,
       <"PointerType" : (
         {
-          "pointer" : 120
+          "pointer" : 174
         },
         {
-          "type_ptr" : 56,
+          "type_ptr" : 111,
           "is_const" : true
         }
       )>,
       <"PointerType" : (
         {
-          "pointer" : 121
+          "pointer" : 175
         },
         {
-          "type_ptr" : 56
+          "type_ptr" : 111
         }
       )>,
       <"RecordType" : (
         {
-          "pointer" : 122
+          "pointer" : 176
         },
-        123
+        177
       )>,
       <"ConstantArrayType" : (
         {
-          "pointer" : 124
+          "pointer" : 178
         },
         {
           "element_type" : {
-            "type_ptr" : 122
+            "type_ptr" : 176
           },
           "stride" : 24
         },
@@ -1815,13 +3402,25 @@
       )>,
       <"ElaboratedType" : (
         {
-          "pointer" : 125,
+          "pointer" : 179,
           "desugared_type" : 13
         }
       )>,
-      <"FunctionProtoType" : (
+      <"RecordType" : (
         {
           "pointer" : 19
+        },
+        18
+      )>,
+      <"RecordType" : (
+        {
+          "pointer" : 21
+        },
+        20
+      )>,
+      <"FunctionProtoType" : (
+        {
+          "pointer" : 48
         },
         {
           "return_type" : {
@@ -1833,15 +3432,15 @@
       )>,
       <"PointerType" : (
         {
-          "pointer" : 126
+          "pointer" : 180
         },
         {
-          "type_ptr" : 121
+          "type_ptr" : 175
         }
       )>,
       <"ElaboratedType" : (
         {
-          "pointer" : 23,
+          "pointer" : 52,
           "desugared_type" : 8
         }
       )>,
@@ -1852,49 +3451,55 @@
         },
         {
           "child_type" : {
-            "type_ptr" : 125
+            "type_ptr" : 179
           },
           "decl_ptr" : 16
         }
       )>,
+      <"ElaboratedType" : (
+        {
+          "pointer" : 83,
+          "desugared_type" : 21
+        }
+      )>,
       <"ObjCObjectType" : (
         {
-          "pointer" : 127
+          "pointer" : 181
         },
         {
-          "base_type" : 110
+          "base_type" : 164
         }
       )>,
       <"ObjCObjectPointerType" : (
         {
-          "pointer" : 128
+          "pointer" : 182
         },
         {
-          "type_ptr" : 127
+          "type_ptr" : 181
         }
       )>,
       <"TypedefType" : (
         {
-          "pointer" : 129,
-          "desugared_type" : 128
+          "pointer" : 183,
+          "desugared_type" : 182
         },
         {
           "child_type" : {
-            "type_ptr" : 128
+            "type_ptr" : 182
           },
-          "decl_ptr" : 130
+          "decl_ptr" : 184
         }
       )>,
       <"TypedefType" : (
         {
-          "pointer" : 53,
-          "desugared_type" : 128
+          "pointer" : 108,
+          "desugared_type" : 182
         },
         {
           "child_type" : {
-            "type_ptr" : 129
+            "type_ptr" : 183
           },
-          "decl_ptr" : 52
+          "decl_ptr" : 107
         }
       )>,
       <"NoneType" : (

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -19,11 +19,6 @@ end
 *)
 module CType : sig
   type id = int (** Unique ID assigned to every type *)
-  
-  type record_field = {
-    ctype: id;
-    name: string;
-  }
 
   type t =
     | Tvoid (** [void] type *)
@@ -41,10 +36,21 @@ module CType : sig
     | Tulonglong (** [unsigned long long] type *)
     | Tfloat (** [float] type *)
     | Tdouble (** [double] type *)
-    | Tarray of id * int (** [Array] type *)
-    | Tpointer of id (** [Pointer] type *)
-    | Trecord of { name: string; fields: record_field list; location: Location.t }
-    | Talias of id (** Just alias of other types. *)
+    | Tarray of t * int (** [Array] type *)
+    | Tpointer of t (** [Pointer] type *)
+    | Tdefined of id (** User defined type like such as struct *)
+end
+
+module Record : sig
+  type field = {
+    ctype: CType.t;
+    name: string;
+  }
+
+  type t = {
+    name: string;
+    fields: field list;
+  }
 end
 
 (**
@@ -91,6 +97,8 @@ and definition =
      [body] is the function's body and function prototype has empty body.
    *)
   | DECDEF of init_name_group * variable_scope * Location.t (** global variable(s) *)
+  | TYPEDEF of CType.id * string * Location.t (** A definition of type *)
+  | RECORDDEF of CType.id * Record.t * Location.t (** A definition of struct *)
 
 and block = statement list
 

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -42,7 +42,7 @@ module CType : sig
 end
 
 type field = {
-  ctype: CType.t;
+  field_type: CType.t;
   field_name: string;
   bit_width_expr: expression option;
 }
@@ -136,6 +136,8 @@ and statement =
    *)
   | VARDECL of init_name_group * variable_scope * Location.t
   (** variable declaration *)
+  | RECORDDEC of CType.id * record * Location.t
+  (** struct definition in statements *)
 
 and binary_operator =
   | ADD (** [e1 + e2] *)

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -41,24 +41,23 @@ module CType : sig
     | Tdefined of id (** User defined type like such as struct *)
 end
 
-module Record : sig
-  type field = {
-    ctype: CType.t;
-    name: string;
-  }
+type field = {
+  ctype: CType.t;
+  field_name: string;
+  bit_width_expr: expression option;
+}
 
-  type t = {
-    name: string;
-    fields: field list;
-  }
-end
+and record = {
+  record_name: string;
+  record_fields: field list;
+}
 
 (**
   like name_group, except the declared variables are allowed to have initializers
   e.g.
     {[int x = 1, y = 2;]}
  *)
-type init_name_group = CType.t * init_name list
+and init_name_group = CType.t * init_name list
 
 (**
   A name of symbol.
@@ -98,7 +97,7 @@ and definition =
    *)
   | DECDEF of init_name_group * variable_scope * Location.t (** global variable(s) *)
   | TYPEDEF of CType.id * string * Location.t (** A definition of type *)
-  | RECORDDEF of CType.id * Record.t * Location.t (** A definition of struct *)
+  | RECORDDEF of CType.id * record * Location.t (** A definition of struct *)
 
 and block = statement list
 
@@ -167,6 +166,7 @@ and unary_operator =
   | POSDECR (** [e--] *)
 
 and expression =
+  | CONST_EXPR of expression * Location.t (** constant expression *)
   | UNARY of unary_operator * expression * Location.t  (** unary operation *)
   | BINARY of binary_operator * expression * expression * Location.t (** binary operation *)
   | CONDITIONAL of expression * expression * expression * Location.t (** conditional operator *)

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -49,6 +49,8 @@ let conv_unary_operator : Ast.unary_operator -> Cabs.unary_operator = function
   | Ast.POSDECR -> Cabs.POSDECR
 
 let rec conv_expression : Ast.expression -> Cabs.expression = function
+  | Ast.CONST_EXPR (expr, _location) ->
+    conv_expression expr (* Simply ignore a constant expression. *)
   | Ast.UNARY (unary_operator, expression, _location) ->
     Cabs.UNARY (
       conv_unary_operator unary_operator,

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -158,6 +158,10 @@ let conv_definition : Ast.definition -> Cabs.definition = function
       conv_init_name_group init_name_group,
       conv_location location
     )
+  | Ast.TYPEDEF _ ->
+    raise (Unimplemented_error "Cabs cannot accept this definition.")
+  | Ast.RECORDDEF _ ->
+    raise (Unimplemented_error "Cabs cannot accept this definition.")
 
 let conv_file (filename, definitions) : Cabs.file = filename, List.map conv_definition definitions
 

--- a/src/lib/ast2cabs.ml
+++ b/src/lib/ast2cabs.ml
@@ -115,6 +115,8 @@ let rec conv_statement : Ast.statement -> Cabs.statement = function
       conv_init_name_group init_name_group,
       conv_location location
     ))
+  | Ast.RECORDDEC (_id, _record, _location) ->
+    raise (Cannot_convert "Cabs does not support the definition in statements")
 
 and conv_block block : Cabs.block = {
   blabels= [];


### PR DESCRIPTION
User-defined types are now treated as pointers to the place where they are defined.
This modification allows recursive types to be handled correctly, as well as a more lexical interpretation of the source code.